### PR TITLE
ax_compiler_flags: Add two extra warning CFLAGS

### DIFF
--- a/m4/ax_compiler_flags.m4
+++ b/m4/ax_compiler_flags.m4
@@ -144,6 +144,8 @@ AC_DEFUN([AX_COMPILER_FLAGS],[
             -Wmissing-include-dirs dnl
             -Wunused-but-set-variable dnl
             -Warray-bounds dnl
+            -Wimplicit-function-declaration dnl
+            -Wreturn-type dnl
             $6 dnl
         ],ax_warn_cflags_variable,[$ax_compiler_flags_test])
         AX_APPEND_COMPILE_FLAGS([$11],


### PR DESCRIPTION
-Wimplicit-function-declaration and -Wreturn-type. These are implicitly
activated by -Wall on GCC, but might not be on other compilers. Best to
be explicit.