### PR TITLE
Split AX_COMPILER_FLAGS into sub-macros for different tools

### DIFF
--- a/m4/ax_compiler_flags.m4
+++ b/m4/ax_compiler_flags.m4
@@ -40,7 +40,11 @@
 #   EXTRA-*-CFLAGS and EXTRA-*-LDFLAGS variables.  Flags should not be
 #   disabled using these arguments, as the entire point of AX_COMPILER_FLAGS
 #   is to enforce a consistent set of useful compiler warnings on code,
-#   using warnings which have been chosen for low false positive rates.
+#   using warnings which have been chosen for low false positive rates.  If a
+#   compiler emits false positives for a warning, a #pragma should be used in
+#   the code to disable the warning locally. See:
+#
+#       https://gcc.gnu.org/onlinedocs/gcc-4.9.2/gcc/Diagnostic-Pragmas.html#Diagnostic-Pragmas
 #
 #   IS-RELEASE can be used to disable -Werror when making a release, which
 #   is useful for those hairy moments when you just want to get the release

--- a/m4/ax_compiler_flags.m4
+++ b/m4/ax_compiler_flags.m4
@@ -55,6 +55,12 @@
 #   be manually added to the CFLAGS and LDFLAGS variables for each target in
 #   the code base.
 #
+#   Warning flags for g-ir-scanner (from GObject Introspection) are AC_SUBST-ed
+#   as WARN_SCANNERFLAGS.  This variable must be manually added to the
+#   SCANNERFLAGS variable for each GIR target in the code base.  If extra
+#   g-ir-scanner flags need to be enabled, the AX_COMPILER_FLAGS_GIR macro must
+#   be invoked manually.
+#
 #   AX_COMPILER_FLAGS may add support for other tools in future, in addition to
 #   the compiler and linker.  No extra EXTRA-* variables will be added for
 #   those tools, and all extra support will still use the single
@@ -71,7 +77,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 3
+#serial 4
 
 AC_DEFUN([AX_COMPILER_FLAGS],[
     AX_REQUIRE_DEFINED([AX_COMPILER_FLAGS_CFLAGS])
@@ -89,4 +95,5 @@ AC_DEFUN([AX_COMPILER_FLAGS],[
 
     AX_COMPILER_FLAGS_CFLAGS([$1],[$3],[$4],[$5],[$6],[$7],[$8])
     AX_COMPILER_FLAGS_LDFLAGS([$2],[$3],[$9],[$10],[$11],[$12],[$13])
+    AX_COMPILER_FLAGS_GIR([WARN_SCANNERFLAGS],[$3])
 ])dnl AX_COMPILER_FLAGS

--- a/m4/ax_compiler_flags_cflags.m4
+++ b/m4/ax_compiler_flags_cflags.m4
@@ -1,0 +1,127 @@
+# ===========================================================================
+#     http://www.gnu.org/software/autoconf-archive/ax_compiler_flags_cflags.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_COMPILER_FLAGS_CFLAGS([VARIABLE], [IS-RELEASE], [EXTRA-BASE-FLAGS], [EXTRA-MINIMUM-FLAGS], [EXTRA-YES-FLAGS], [EXTRA-MAXIMUM-FLAGS], [EXTRA-ERROR-FLAGS])
+#
+# DESCRIPTION
+#
+#   Add warning flags for the C compiler to VARIABLE, which defaults to
+#   WARN_CFLAGS.  VARIABLE is AC_SUBST-ed by this macro, but must be manually
+#   added to the CFLAGS variable for each target in the code base.
+#
+#   This macro depends on the environment set up by AX_COMPILER_FLAGS.
+#   Specifically, it uses the value of $ax_enable_compile_warnings to decide
+#   which flags to enable.
+#
+# LICENSE
+#
+#   Copyright (c) 2014, 2015 Philip Withnall <philip@tecnocode.co.uk>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 1
+
+AC_DEFUN([AX_COMPILER_FLAGS_CFLAGS],[
+    AX_REQUIRE_DEFINED([AX_APPEND_COMPILE_FLAGS])
+    AX_REQUIRE_DEFINED([AX_APPEND_FLAG])
+    AX_REQUIRE_DEFINED([AX_CHECK_COMPILE_FLAG])
+
+    # Variable names
+    m4_define(ax_warn_cflags_variable,
+              [m4_normalize(ifelse([$1],,[WARN_CFLAGS],[$1]))])
+
+    # Always pass -Werror=unknown-warning-option to get Clang to fail on bad
+    # flags, otherwise they are always appended to the warn_cflags variable, and
+    # Clang warns on them for every compilation unit.
+    # If this is passed to GCC, it will explode, so the flag must be enabled
+    # conditionally.
+    AX_CHECK_COMPILE_FLAG([-Werror=unknown-warning-option],[
+        ax_compiler_flags_test="-Werror=unknown-warning-option"
+    ],[
+        ax_compiler_flags_test=""
+    ])
+
+    # Base flags
+    AX_APPEND_COMPILE_FLAGS([ dnl
+        -fno-strict-aliasing dnl
+        $4 dnl
+    ],ax_warn_cflags_variable,[$ax_compiler_flags_test])
+
+    AS_IF([test "$ax_enable_compile_warnings" != "no"],[
+        # "minimum" flags
+        AX_APPEND_COMPILE_FLAGS([ dnl
+            -Wall dnl
+            $5 dnl
+        ],ax_warn_cflags_variable,[$ax_compiler_flags_test])
+    ])
+    AS_IF([test "$ax_enable_compile_warnings" != "no" -a \
+                "$ax_enable_compile_warnings" != "minimum"],[
+        # "yes" flags
+        AX_APPEND_COMPILE_FLAGS([ dnl
+            -Wextra dnl
+            -Wundef dnl
+            -Wnested-externs dnl
+            -Wwrite-strings dnl
+            -Wpointer-arith dnl
+            -Wmissing-declarations dnl
+            -Wmissing-prototypes dnl
+            -Wstrict-prototypes dnl
+            -Wredundant-decls dnl
+            -Wno-unused-parameter dnl
+            -Wno-missing-field-initializers dnl
+            -Wdeclaration-after-statement dnl
+            -Wformat=2 dnl
+            -Wold-style-definition dnl
+            -Wcast-align dnl
+            -Wformat-nonliteral dnl
+            -Wformat-security dnl
+            -Wsign-compare dnl
+            -Wstrict-aliasing dnl
+            -Wshadow dnl
+            -Winline dnl
+            -Wpacked dnl
+            -Wmissing-format-attribute dnl
+            -Wmissing-noreturn dnl
+            -Winit-self dnl
+            -Wredundant-decls dnl
+            -Wmissing-include-dirs dnl
+            -Wunused-but-set-variable dnl
+            -Warray-bounds dnl
+            -Wimplicit-function-declaration dnl
+            -Wreturn-type dnl
+            $6 dnl
+        ],ax_warn_cflags_variable,[$ax_compiler_flags_test])
+    ])
+    AS_IF([test "$ax_enable_compile_warnings" = "maximum" -o \
+                "$ax_enable_compile_warnings" = "error"],[
+        # "maximum" flags
+        AX_APPEND_COMPILE_FLAGS([ dnl
+            -Wswitch-enum dnl
+            -Wswitch-default dnl
+            -Waggregate-return dnl
+            $7 dnl
+        ],ax_warn_cflags_variable,[$ax_compiler_flags_test])
+    ])
+    AS_IF([test "$ax_enable_compile_warnings" = "error"],[
+        # "error" flags; -Werror has to be appended unconditionally because
+        # it’s not possible to test for
+        #
+        # suggest-attribute=format is disabled because it gives too many false
+        # positives
+        AX_APPEND_FLAG([-Werror],ax_warn_cflags_variable)
+
+        AX_APPEND_COMPILE_FLAGS([ dnl
+            -Wno-suggest-attribute=format dnl
+            $8 dnl
+        ],ax_warn_cflags_variable,[$ax_compiler_flags_test])
+    ])
+
+    # Substitute the variables
+    AC_SUBST(ax_warn_cflags_variable)
+])dnl AX_COMPILER_FLAGS

--- a/m4/ax_compiler_flags_gir.m4
+++ b/m4/ax_compiler_flags_gir.m4
@@ -1,0 +1,68 @@
+# ===========================================================================
+#     http://www.gnu.org/software/autoconf-archive/ax_compiler_flags_gir.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_COMPILER_FLAGS_GIR([VARIABLE], [IS-RELEASE], [EXTRA-BASE-FLAGS], [EXTRA-MINIMUM-FLAGS], [EXTRA-YES-FLAGS], [EXTRA-MAXIMUM-FLAGS], [EXTRA-ERROR-FLAGS])
+#
+# DESCRIPTION
+#
+#   Add warning flags for the g-ir-scanner (from GObject Introspection) to
+#   VARIABLE, which defaults to WARN_SCANNERFLAGS.  VARIABLE is AC_SUBST-ed by
+#   this macro, but must be manually added to the SCANNERFLAGS variable for
+#   each GIR target in the code base.
+#
+#   This macro depends on the environment set up by AX_COMPILER_FLAGS.
+#   Specifically, it uses the value of $ax_enable_compile_warnings to decide
+#   which flags to enable.
+#
+# LICENSE
+#
+#   Copyright (c) 2015 Philip Withnall <philip@tecnocode.co.uk>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 1
+
+AC_DEFUN([AX_COMPILER_FLAGS_GIR],[
+    AX_REQUIRE_DEFINED([AX_APPEND_FLAG])
+
+    # Variable names
+    m4_define(ax_warn_scannerflags_variable,
+              [m4_normalize(ifelse([$1],,[WARN_SCANNERFLAGS],[$1]))])
+
+    # Base flags
+    AX_APPEND_FLAG([$3],ax_warn_scannerflags_variable)
+
+    AS_IF([test "$ax_enable_compile_warnings" != "no"],[
+        # "minimum" flags
+        AX_APPEND_FLAG([ dnl
+            --warn-all dnl
+            $4 dnl
+        ],ax_warn_scannerflags_variable)
+    ])	
+    AS_IF([test "$ax_enable_compile_warnings" != "no" -a \
+                "$ax_enable_compile_warnings" != "minimum"],[
+        # "yes" flags
+        AX_APPEND_FLAG([$5],ax_warn_scannerflags_variable)
+    ])
+    AS_IF([test "$ax_enable_compile_warnings" = "maximum" -o \
+                "$ax_enable_compile_warnings" = "error"],[
+        # "maximum" flags
+        AX_APPEND_FLAG([$6],ax_warn_scannerflags_variable)
+    ])
+    AS_IF([test "$ax_enable_compile_warnings" = "error"],[
+        # "error" flags
+        AX_APPEND_FLAG([ dnl
+            --warn-error dnl
+            $7 dnl
+        ],ax_warn_scannerflags_variable)
+    ])
+
+    # Substitute the variables
+    AC_SUBST(ax_warn_scannerflags_variable)
+])dnl AX_COMPILER_FLAGS

--- a/m4/ax_compiler_flags_ldflags.m4
+++ b/m4/ax_compiler_flags_ldflags.m4
@@ -1,0 +1,90 @@
+# ===========================================================================
+#     http://www.gnu.org/software/autoconf-archive/ax_compiler_flags_ldflags.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_COMPILER_FLAGS_LDFLAGS([VARIABLE], [IS-RELEASE], [EXTRA-BASE-FLAGS], [EXTRA-MINIMUM-FLAGS], [EXTRA-YES-FLAGS], [EXTRA-MAXIMUM-FLAGS], [EXTRA-ERROR-FLAGS])
+#
+# DESCRIPTION
+#
+#   Add warning flags for the linker to VARIABLE, which defaults to
+#   WARN_LDFLAGS.  VARIABLE is AC_SUBST-ed by this macro, but must be manually
+#   added to the LDFLAGS variable for each target in the code base.
+#
+#   This macro depends on the environment set up by AX_COMPILER_FLAGS.
+#   Specifically, it uses the value of $ax_enable_compile_warnings to decide
+#   which flags to enable.
+#
+# LICENSE
+#
+#   Copyright (c) 2014, 2015 Philip Withnall <philip@tecnocode.co.uk>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 1
+
+AC_DEFUN([AX_COMPILER_FLAGS_LDFLAGS],[
+    AX_REQUIRE_DEFINED([AX_APPEND_COMPILE_FLAGS])
+    AX_REQUIRE_DEFINED([AX_APPEND_FLAG])
+    AX_REQUIRE_DEFINED([AX_CHECK_COMPILE_FLAG])
+
+    # Variable names
+    m4_define(ax_warn_ldflags_variable,
+              [m4_normalize(ifelse([$1],,[WARN_LDFLAGS],[$1]))])
+
+    # Always pass -Werror=unknown-warning-option to get Clang to fail on bad
+    # flags, otherwise they are always appended to the warn_ldflags variable,
+    # and Clang warns on them for every compilation unit.
+    # If this is passed to GCC, it will explode, so the flag must be enabled
+    # conditionally.
+    AX_CHECK_COMPILE_FLAG([-Werror=unknown-warning-option],[
+        ax_compiler_flags_test="-Werror=unknown-warning-option"
+    ],[
+        ax_compiler_flags_test=""
+    ])
+
+    # Base flags
+    AX_APPEND_COMPILE_FLAGS([ dnl
+        -Wl,--no-as-needed dnl
+        $3 dnl
+    ],ax_warn_ldflags_variable,[$ax_compiler_flags_test])
+
+    AS_IF([test "$ax_enable_compile_warnings" != "no"],[
+        # "minimum" flags
+        AX_APPEND_COMPILE_FLAGS([$4],
+                                ax_warn_ldflags_variable,
+                                [$ax_compiler_flags_test])
+    ])
+    AS_IF([test "$ax_enable_compile_warnings" != "no" -a \
+                "$ax_enable_compile_warnings" != "minimum"],[
+        # "yes" flags
+        AX_APPEND_COMPILE_FLAGS([$5],
+                                ax_warn_ldflags_variable,
+                                [$ax_compiler_flags_test])
+    ])
+    AS_IF([test "$ax_enable_compile_warnings" = "maximum" -o \
+                "$ax_enable_compile_warnings" = "error"],[
+        # "maximum" flags
+        AX_APPEND_COMPILE_FLAGS([$6],
+                                ax_warn_ldflags_variable,
+                                [$ax_compiler_flags_test])
+    ])
+    AS_IF([test "$ax_enable_compile_warnings" = "error"],[
+        # "error" flags; -Werror has to be appended unconditionally because
+        # it’s not possible to test for
+        #
+        # suggest-attribute=format is disabled because it gives too many false
+        # positives
+        AX_APPEND_COMPILE_FLAGS([ dnl
+            -Wl,--fatal-warnings dnl
+            $7 dnl
+        ],ax_warn_ldflags_variable,[$ax_compiler_flags_test])
+    ])
+
+    # Substitute the variables
+    AC_SUBST(ax_warn_ldflags_variable)
+])dnl AX_COMPILER_FLAGS


### PR DESCRIPTION
See the two commit messages for justification. Split AX_COMPILER_FLAGS (without breaking its API) into sub-macros for different tools, initially supporting the C compiler and linker, and then adding support for g-ir-scanner from GObject Introspection (https://wiki.gnome.org/Projects/GObjectIntrospection).