### PR TITLE
Add AX_IS_RELEASE macro

### DIFF
--- a/m4/ax_check_enable_debug.m4
+++ b/m4/ax_check_enable_debug.m4
@@ -4,7 +4,7 @@
 #
 # SYNOPSIS
 #
-#   AX_CHECK_ENABLE_DEBUG([enable by default=yes/info/profile/no], [ENABLE DEBUG VARIABLES ...], [DISABLE DEBUG VARIABLES NDEBUG ...])
+#   AX_CHECK_ENABLE_DEBUG([enable by default=yes/info/profile/no], [ENABLE DEBUG VARIABLES ...], [DISABLE DEBUG VARIABLES NDEBUG ...], [IS-RELEASE])
 #
 # DESCRIPTION
 #
@@ -25,16 +25,23 @@
 #   If debug is not enabled, ensure AC_PROG_* will not add debugging flags.
 #   Should be invoked prior to any AC_PROG_* compiler checks.
 #
+#   IS-RELEASE can be used to change the default to 'no' when making a
+#   release.  Set IS-RELEASE to 'yes' or 'no' as appropriate, for example by
+#   using the AX_IS_RELEASE macro:
+#
+#     AX_IS_RELEASE([git-directory])
+#     AX_CHECK_ENABLE_DEBUG(,,,[$ax_is_release])
+#
 # LICENSE
 #
 #   Copyright (c) 2011 Rhys Ulerich <rhys.ulerich@gmail.com>
-#   Copyright (c) 2014 Philip Withnall <philip@tecnocode.co.uk>
+#   Copyright (c) 2014, 2015 Philip Withnall <philip@tecnocode.co.uk>
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice
 #   and this notice are preserved.
 
-#serial 3
+#serial 4
 
 AC_DEFUN([AX_CHECK_ENABLE_DEBUG],[
     AC_BEFORE([$0],[AC_PROG_CC])dnl
@@ -44,13 +51,18 @@ AC_DEFUN([AX_CHECK_ENABLE_DEBUG],[
 
     AC_MSG_CHECKING(whether to enable debugging)
 
-    m4_define(ax_enable_debug_default,[m4_tolower(m4_normalize(ifelse([$1],,[no],[$1])))])
+    ax_enable_debug_default=m4_tolower(m4_normalize(ifelse([$1],,[no],[$1])))
+
+    # If this is a release, override the default.
+    AS_IF([test "$4" = "yes"],
+      [ax_enable_debug_default="no"])
+
     m4_define(ax_enable_debug_vars,[m4_normalize(ifelse([$2],,,[$2]))])
     m4_define(ax_disable_debug_vars,[m4_normalize(ifelse([$3],,[NDEBUG],[$3]))])
 
     AC_ARG_ENABLE(debug,
-	[AS_HELP_STRING([--enable-debug]@<:@=ax_enable_debug_default@:>@,[compile with debugging; one of yes/info/profile/no])],
-	[],enable_debug=ax_enable_debug_default)
+	[AS_HELP_STRING([--enable-debug=]@<:@yes/info/profile/no@:>@,[compile with debugging])],
+	[],enable_debug=$ax_enable_debug_default)
 
     # empty mean debug yes
     AS_IF([test "x$enable_debug" = "x"],

--- a/m4/ax_is_release.m4
+++ b/m4/ax_is_release.m4
@@ -1,0 +1,60 @@
+# ===================================================================
+#   http://www.gnu.org/software/autoconf-archive/ax_is_release.html
+# ===================================================================
+#
+# SYNOPSIS
+#
+#   AX_IS_RELEASE(POLICY)
+#
+# DESCRIPTION
+#
+#   Determine whether the code is being configured as a release, or from git.
+#   Set the ax_is_release variable to 'yes' or 'no'.
+#
+#   If building a release version, it is recommended that the configure script
+#   disable compiler errors and debug features, by conditionalising them on
+#   the ax_is_release variable.  If building from git, these features should
+#   be enabled.
+#
+#   The POLICY parameter specifies how ax_is_release is determined. It can
+#   take the following values:
+#
+#    * git-directory:  ax_is_release will be 'no' if a '.git' directory exists
+#    * minor-version:  ax_is_release will be 'no' if the minor version number
+#                      in $PACKAGE_VERSION is odd; this assumes
+#                      $PACKAGE_VERSION follows the 'major.minor.micro' scheme
+#    * always:         ax_is_release will always be 'yes'
+#    * never:          ax_is_release will always be 'no'
+#
+#   Other policies may be added in future.
+#
+# LICENSE
+#
+#   Copyright (c) 2015 Philip Withnall <philip@tecnocode.co.uk>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.
+
+#serial 1
+
+AC_DEFUN([AX_IS_RELEASE],[
+    AC_BEFORE([AC_INIT],[$0])
+
+    m4_case([$1],
+      [git-directory],[
+        # $is_release = (.git directory does not exist)
+        AS_IF([test -d .git],[ax_is_release=no],[ax_is_release=yes])
+      ],
+      [minor-version],[
+        # $is_release = ($minor_version is even)
+        minor_version=`echo "$PACKAGE_VERSION" | sed 's/[[^.]][[^.]]*.\([[^.]][[^.]]*\).*/\1/'`
+        AS_IF([test "$(( $minor_version % 2 ))" -ne 0],
+              [ax_is_release=no],[ax_is_release=yes])
+      ],
+      [always],[ax_is_release=yes],
+      [never],[ax_is_release=no],
+      [
+        AC_MSG_ERROR([Invalid policy. Valid policies: git-directory, minor-version.])
+      ])
+])


### PR DESCRIPTION
A macro to determine whether this is a release build or a development one, following one of a given set of policies. This can then be plumbed in to disable debug code, or similar.