### PR TITLE
ax_compiler_flags: Add a --disable-Werror option

### DIFF
--- a/m4/ax_compiler_flags.m4
+++ b/m4/ax_compiler_flags.m4
@@ -25,7 +25,9 @@
 #
 #   By providing a consistent --enable-compile-warnings argument across all
 #   projects using this macro, continuous integration systems can easily be
-#   configured the same for all projects.
+#   configured the same for all projects.  Automated systems or build
+#   systems aimed at beginners may want to pass the --disable-Werror
+#   argument to unconditionally prevent warnings being fatal.
 #
 #   --enable-compile-warnings can take the values:
 #
@@ -35,6 +37,8 @@
 #    * maximum: The above, plus additional warnings which enforce a particular
 #               coding style
 #    * error:   The above, plus -Werror so that all warnings are fatal.
+#               Use --disable-Werror to override this and disable fatal
+#               warnings.
 #
 #   The set of flags enabled at each level can be augmented using the
 #   EXTRA-*-CFLAGS and EXTRA-*-LDFLAGS variables.  Flags should not be
@@ -83,7 +87,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AC_DEFUN([AX_COMPILER_FLAGS],[
     AX_REQUIRE_DEFINED([AX_COMPILER_FLAGS_CFLAGS])
@@ -96,8 +100,17 @@ AC_DEFUN([AX_COMPILER_FLAGS],[
                   [AS_IF([test "$3" = "yes"],
                          [enable_compile_warnings="yes"],
                          [enable_compile_warnings="error"])])
+    AC_ARG_ENABLE([Werror],
+                  AS_HELP_STRING([--disable-Werror],
+                                 [Unconditionally make all compiler warnings non-fatal]),,
+                  [enable_Werror=maybe])
 
     # Return the user’s chosen warning level
+    AS_IF([test "$enable_Werror" = "no" -a \
+                "$enable_compile_warnings" = "error"],[
+        enable_compile_warnings="maximum"
+    ])
+
     ax_enable_compile_warnings=$enable_compile_warnings
 
     AX_COMPILER_FLAGS_CFLAGS([$1],[$3],[$4],[$5],[$6],[$7],[$8])

--- a/m4/ax_compiler_flags_cflags.m4
+++ b/m4/ax_compiler_flags_cflags.m4
@@ -25,7 +25,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 3
+#serial 4
 
 AC_DEFUN([AX_COMPILER_FLAGS_CFLAGS],[
     AX_REQUIRE_DEFINED([AX_APPEND_COMPILE_FLAGS])
@@ -53,6 +53,10 @@ AC_DEFUN([AX_COMPILER_FLAGS_CFLAGS],[
         $3 dnl
     ],ax_warn_cflags_variable,[$ax_compiler_flags_test])
 
+    # In the flags below, when disabling specific flags, always add *both*
+    # -Wno-foo and -Wno-error=foo. This fixes the situation where (for example)
+    # we enable -Werror, disable a flag, and a build bot passes CFLAGS=-Wall,
+    # which effectively turns that flag back on again as an error.
     AS_IF([test "$ax_enable_compile_warnings" != "no"],[
         # "minimum" flags
         AX_APPEND_COMPILE_FLAGS([ dnl
@@ -74,7 +78,9 @@ AC_DEFUN([AX_COMPILER_FLAGS_CFLAGS],[
             -Wstrict-prototypes dnl
             -Wredundant-decls dnl
             -Wno-unused-parameter dnl
+            -Wno-error=unused-parameter dnl
             -Wno-missing-field-initializers dnl
+            -Wno-error=missing-field-initializers dnl
             -Wdeclaration-after-statement dnl
             -Wformat=2 dnl
             -Wold-style-definition dnl

--- a/m4/ax_compiler_flags_cxxflags.m4
+++ b/m4/ax_compiler_flags_cxxflags.m4
@@ -26,7 +26,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 1
+#serial 2
 
 AC_DEFUN([AX_COMPILER_FLAGS_CXXFLAGS],[
     AX_REQUIRE_DEFINED([AX_APPEND_COMPILE_FLAGS])
@@ -56,6 +56,10 @@ AC_DEFUN([AX_COMPILER_FLAGS_CXXFLAGS],[
         $3 dnl
     ],ax_warn_cxxflags_variable,[$ax_compiler_flags_test])
 
+    # In the flags below, when disabling specific flags, always add *both*
+    # -Wno-foo and -Wno-error=foo. This fixes the situation where (for example)
+    # we enable -Werror, disable a flag, and a build bot passes CFLAGS=-Wall,
+    # which effectively turns that flag back on again as an error.
     AS_IF([test "$ax_enable_compile_warnings" != "no"],[
         # "minimum" flags
         AX_APPEND_COMPILE_FLAGS([ dnl
@@ -74,7 +78,9 @@ AC_DEFUN([AX_COMPILER_FLAGS_CXXFLAGS],[
             -Wmissing-declarations dnl
             -Wredundant-decls dnl
             -Wno-unused-parameter dnl
+            -Wno-error=unused-parameter dnl
             -Wno-missing-field-initializers dnl
+            -Wno-error=missing-field-initializers dnl
             -Wformat=2 dnl
             -Wcast-align dnl
             -Wformat-nonliteral dnl
@@ -93,6 +99,7 @@ AC_DEFUN([AX_COMPILER_FLAGS_CXXFLAGS],[
             -Warray-bounds dnl
             -Wreturn-type dnl
             -Wno-overloaded-virtual dnl
+            -Wno-error=overloaded-virtual dnl
             $5 dnl
         ],ax_warn_cxxflags_variable,[$ax_compiler_flags_test])
     ])


### PR DESCRIPTION
Add a --disable-Werror option to unconditionally disable -Werror, independently of the warning level set with --enable-compile-warnings.

Minor fix for disabling some compiler warnings when used in the presence of a build bot which adds its own flags.