### PR TITLE
AX_CXX_COMPILE_STDCXX_0X: Fix for -Werror=missing-declarations

### DIFF
--- a/m4/ax_cxx_compile_stdcxx_11.m4
+++ b/m4/ax_cxx_compile_stdcxx_11.m4
@@ -77,6 +77,8 @@ m4_define([_AX_CXX_COMPILE_STDCXX_11_testbody], [[
         template<typename T>
         void func(member<T>*) {}
 
+        void test();
+
         void test() {
             func<foo>(0);
         }


### PR DESCRIPTION
This fixes the following error:

    conftest.cpp:49:14: error: no previous declaration for 'void
    test_template_alias_sfinae::test()' [-Werror=missing-declarations]

I was told in znc/znc#863 to send this here. ;-)