### PR TITLE
bootstrap.sh: Support a --copy option to automatically clone gnulib

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,6 +2,10 @@
 
 set -eu
 
+if [ ! -d "gnulib" ] && [ $# -gt 0 ] && [ "$1" = "--copy" ]; then
+  git clone git://git.savannah.gnu.org/gnulib.git gnulib
+fi
+
 if [ -x "gnulib/gnulib-tool" ]; then
   gnulibtool=gnulib/gnulib-tool
 else


### PR DESCRIPTION
When building autoconf-archive using build bots or JHBuild, it is quite
desirable to have a single command which will bootstrap the entire build
process, up to the point where `make` can be run.

bootstrap.sh is supposed to do this, but will fail if gnulib is not
present. Add a --copy option which will automatically clone gnulib into
the source directory if it’s not present.