### PR TITLE
ax-is-release: Add micro-version policy

### DIFF
--- a/m4/ax_is_release.m4
+++ b/m4/ax_is_release.m4
@@ -23,6 +23,9 @@
 #    * minor-version:  ax_is_release will be 'no' if the minor version number
 #                      in $PACKAGE_VERSION is odd; this assumes
 #                      $PACKAGE_VERSION follows the 'major.minor.micro' scheme
+#    * micro-version:  ax_is_release will be 'no' if the micro version number
+#                      in $PACKAGE_VERSION is odd; this assumes
+#                      $PACKAGE_VERSION follows the 'major.minor.micro' scheme
 #    * always:         ax_is_release will always be 'yes'
 #    * never:          ax_is_release will always be 'no'
 #
@@ -36,7 +39,7 @@
 #   permitted in any medium without royalty provided the copyright notice
 #   and this notice are preserved.
 
-#serial 2
+#serial 3
 
 AC_DEFUN([AX_IS_RELEASE],[
     AC_BEFORE([AC_INIT],[$0])
@@ -50,6 +53,12 @@ AC_DEFUN([AX_IS_RELEASE],[
         # $is_release = ($minor_version is even)
         minor_version=`echo "$PACKAGE_VERSION" | sed 's/[[^.]][[^.]]*.\([[^.]][[^.]]*\).*/\1/'`
         AS_IF([test "$(( $minor_version % 2 ))" -ne 0],
+              [ax_is_release=no],[ax_is_release=yes])
+      ],
+      [micro-version],[
+        # $is_release = ($micro_version is even)
+        micro_version=`echo "$PACKAGE_VERSION" | sed 's/[[^.]]*\.[[^.]]*\.\([[^.]]*\).*/\1/'`
+        AS_IF([test "$(( $micro_version % 2 ))" -ne 0],
               [ax_is_release=no],[ax_is_release=yes])
       ],
       [always],[ax_is_release=yes],


### PR DESCRIPTION
The are various projects that use the micro version of $PACKAGE_VERSION
as an indication of whether the code is a release or if it's a snapshot
of the source under revision control.

The micro-version policy follows the existing minor-version policy in
spirit, if not in regular expression.

Signed-off-by: Emmanuele Bassi <ebassi@gnome.org>