### PR TITLE
ax_python_module[_version]: Add Python 3 support.

### DIFF
--- a/m4/ax_python_module.m4
+++ b/m4/ax_python_module.m4
@@ -4,13 +4,15 @@
 #
 # SYNOPSIS
 #
-#   AX_PYTHON_MODULE(modname[, fatal])
+#   AX_PYTHON_MODULE(modname[, fatal, python])
 #
 # DESCRIPTION
 #
 #   Checks for Python module.
 #
 #   If fatal is non-empty then absence of a module will trigger an error.
+#   The third parameter can either be "python" for Python 2 or "python3" for
+#   Python 3; defaults to Python 3.
 #
 # LICENSE
 #
@@ -21,13 +23,18 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_PYTHON_MODULE], [AX_PYTHON_MODULE])
 AC_DEFUN([AX_PYTHON_MODULE],[
     if test -z $PYTHON;
     then
-        PYTHON="python"
+        if test -z "$3";
+        then
+            PYTHON="python3"
+        else
+            PYTHON="$3"
+        fi
     fi
     PYTHON_NAME=`basename $PYTHON`
     AC_MSG_CHECKING($PYTHON_NAME module: $1)

--- a/m4/ax_python_module.m4
+++ b/m4/ax_python_module.m4
@@ -21,7 +21,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 6
+#serial 7
 
 AU_ALIAS([AC_PYTHON_MODULE], [AX_PYTHON_MODULE])
 AC_DEFUN([AX_PYTHON_MODULE],[
@@ -31,19 +31,19 @@ AC_DEFUN([AX_PYTHON_MODULE],[
     fi
     PYTHON_NAME=`basename $PYTHON`
     AC_MSG_CHECKING($PYTHON_NAME module: $1)
-	$PYTHON -c "import $1" 2>/dev/null
-	if test $? -eq 0;
-	then
-		AC_MSG_RESULT(yes)
-		eval AS_TR_CPP(HAVE_PYMOD_$1)=yes
-	else
-		AC_MSG_RESULT(no)
-		eval AS_TR_CPP(HAVE_PYMOD_$1)=no
-		#
-		if test -n "$2"
-		then
-			AC_MSG_ERROR(failed to find required module $1)
-			exit 1
-		fi
-	fi
+    $PYTHON -c "import $1" 2>/dev/null
+    if test $? -eq 0;
+    then
+        AC_MSG_RESULT(yes)
+        eval AS_TR_CPP(HAVE_PYMOD_$1)=yes
+    else
+        AC_MSG_RESULT(no)
+        eval AS_TR_CPP(HAVE_PYMOD_$1)=no
+        #
+        if test -n "$2"
+        then
+            AC_MSG_ERROR(failed to find required module $1)
+            exit 1
+        fi
+    fi
 ])

--- a/m4/ax_python_module_version.m4
+++ b/m4/ax_python_module_version.m4
@@ -4,13 +4,15 @@
 #
 # SYNOPSIS
 #
-#   AX_PYTHON_MODULE_VERSION(modname, min_version)
+#   AX_PYTHON_MODULE_VERSION(modname, min_version[, python])
 #
 # DESCRIPTION
 #
 #   Checks for Python module with at least the given version.
 #
 #   Triggers an error if module is absent or present but at a lower version.
+#   The third parameter can either be "python" for Python 2 or "python3" for
+#   Python 3; defaults to Python 3.
 #
 # LICENSE
 #
@@ -21,10 +23,10 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 1
+#serial 2
 
 AC_DEFUN([AX_PYTHON_MODULE_VERSION], [
-    AX_PYTHON_MODULE([$1], [required])
+    AX_PYTHON_MODULE([$1], [required], [$3])
     AC_MSG_CHECKING([for version $2 or higher of $1])
     $PYTHON -c "import sys, $1; from distutils.version import StrictVersion; sys.exit(StrictVersion($1.__version__) < StrictVersion('$2'))" 2> /dev/null
     AS_IF([test $? -eq 0], [], [


### PR DESCRIPTION
Permit dependency checking of both Python 2 and Python 3 modules.