### PR TITLE
ax_cxx_compile_stdcxx_11.m4: Support HP aCC

### DIFF
--- a/m4/ax_cxx_compile_stdcxx_11.m4
+++ b/m4/ax_cxx_compile_stdcxx_11.m4
@@ -34,7 +34,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 10
+#serial 11
 
 m4_define([_AX_CXX_COMPILE_STDCXX_11_testbody], [[
   template <typename T>
@@ -128,7 +128,9 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX_11], [dnl
 
   m4_if([$1], [ext], [], [dnl
   if test x$ac_success = xno; then
-    for switch in -std=c++11 -std=c++0x; do
+    dnl HP's aCC needs +std=c++11 according to:
+    dnl http://h21007.www2.hp.com/portal/download/files/unprot/aCxx/PDF_Release_Notes/769149-001.pdf
+    for switch in -std=c++11 -std=c++0x +std=c++11; do
       cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx11_$switch])
       AC_CACHE_CHECK(whether $CXX supports C++11 features with $switch,
                      $cachevar,


### PR DESCRIPTION
This compiler needs +std=c++11 to enable C++11 mode:
http://h21007.www2.hp.com/portal/download/files/unprot/aCxx/PDF_Release_Notes/769149-001.pdf

We've just switched Xapian (http://xapian.org/) to requiring C++11, so I am going through checking for any options needed to enable C++11 support in compilers people have previously reported success at building Xapian with.  Unfortunately I don't have access to most of these compilers myself, so I haven't been able to verify that this change enables current aCC to compile the test program the macro uses.

This document seems to suggest aCC is OK except for lacking support for `override`:

http://h21007.www2.hp.com/portal/site/dspp/menuitem.863c3e4cbcdc3f3515b49c108973a801?ciid=887a551fac19b410VgnVCM200000a460ea10RCRD

Despite this, I'm proposing this change as aCC isn't going to do worse than it does without us trying this option, and adding it now it will mean this macro is ready when aCC gains support for `override`.  Also, trying this option shouldn't negatively affect other compilers.