### PR TITLE
ax_append_flag: Fix regression if flag has a ','.

### DIFF
--- a/m4/ax_append_flag.m4
+++ b/m4/ax_append_flag.m4
@@ -59,7 +59,7 @@ AS_VAR_SET_IF(FLAGS,[
   AS_CASE([" AS_VAR_GET(FLAGS) "],
     [*" $1 "*], [AC_RUN_LOG([: FLAGS already contains $1])],
     [
-     AS_VAR_APPEND(FLAGS," $1")
+     AS_VAR_APPEND(FLAGS,[" $1"])
      AC_RUN_LOG([: FLAGS="$FLAGS"])
     ])
   ],


### PR DESCRIPTION
Below is a small fix for AX_APPEND_FLAG when the flag to be appended has a comma in it.