### PR TITLE
ax_valgrind_check: Fix a bash-4-ism

### DIFF
--- a/m4/ax_valgrind_check.m4
+++ b/m4/ax_valgrind_check.m4
@@ -85,7 +85,7 @@ AC_DEFUN([AX_VALGRIND_CHECK],[
 			m4_define([ax_cv_var],[ax_cv_valgrind_tool_]vgtooln)
 			AC_CACHE_CHECK([for Valgrind tool ]vgtool,ax_cv_var,[
 				ax_cv_var=
-				AS_IF([`$VALGRIND --tool=vgtool --help 2&>/dev/null`],[
+				AS_IF([`$VALGRIND --tool=vgtool --help >/dev/null 2>&1`],[
 					ax_cv_var="vgtool"
 				])
 			])


### PR DESCRIPTION
The ‘2&>’ syntax requires a recent version of bash. Use ‘>… 2>&1’
instead to reduce the requirement.