### PR TITLE
Check for attribute support with C++11 macro

### DIFF
--- a/m4/ax_cxx_compile_stdcxx_11.m4
+++ b/m4/ax_cxx_compile_stdcxx_11.m4
@@ -28,13 +28,14 @@
 #   Copyright (c) 2012 Zack Weinberg <zackw@panix.com>
 #   Copyright (c) 2013 Roy Stogner <roystgnr@ices.utexas.edu>
 #   Copyright (c) 2014, 2015 Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
+#   Copyright (c) 2015 Paul Norman <penorman@mac.com>
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 11
+#serial 12
 
 m4_define([_AX_CXX_COMPILE_STDCXX_11_testbody], [[
   template <typename T>
@@ -84,6 +85,9 @@ m4_define([_AX_CXX_COMPILE_STDCXX_11_testbody], [[
             func<foo>(0);
         }
     }
+
+    // Check for C++11 attribute support
+    void noret [[noreturn]] () { throw 0; }
 ]])
 
 AC_DEFUN([AX_CXX_COMPILE_STDCXX_11], [dnl


### PR DESCRIPTION
Some compilers pass the other tests while not implementing this part of the C++11 specification. The test used also does not cause warnings with GCC or Clang, and can be used with -Werror.

After this change, GCC 4.7 no longer passes the tests. This macro is about compiler support, not standard library support, but the libstdc++ that comes with GCC 4.7 doesn't support emplace on standard library containers, so many C++11 programs would fail at compile-time on most systems using GCC 4.7.

This is my first autoconf archive submission, so I'm not sure if there's anything else I need to add.

Cross-ref openstreetmap/osm2pgsql#434