### PR TITLE
AX_COMPILER_FLAGS_LDFLAGS: use AX_APPEND_LINK_FLAGS

### DIFF
--- a/m4/ax_compiler_flags_ldflags.m4
+++ b/m4/ax_compiler_flags_ldflags.m4
@@ -28,7 +28,7 @@
 #serial 4
 
 AC_DEFUN([AX_COMPILER_FLAGS_LDFLAGS],[
-    AX_REQUIRE_DEFINED([AX_APPEND_COMPILE_FLAGS])
+    AX_REQUIRE_DEFINED([AX_APPEND_LINK_FLAGS])
     AX_REQUIRE_DEFINED([AX_APPEND_FLAG])
     AX_REQUIRE_DEFINED([AX_CHECK_COMPILE_FLAG])
 
@@ -48,14 +48,14 @@ AC_DEFUN([AX_COMPILER_FLAGS_LDFLAGS],[
     ])
 
     # Base flags
-    AX_APPEND_COMPILE_FLAGS([ dnl
+    AX_APPEND_LINK_FLAGS([ dnl
         -Wl,--no-as-needed dnl
         $3 dnl
     ],ax_warn_ldflags_variable,[$ax_compiler_flags_test])
 
     AS_IF([test "$ax_enable_compile_warnings" != "no"],[
         # "yes" flags
-        AX_APPEND_COMPILE_FLAGS([$4 $5 $6 $7],
+        AX_APPEND_LINK_FLAGS([$4 $5 $6 $7],
                                 ax_warn_ldflags_variable,
                                 [$ax_compiler_flags_test])
     ])
@@ -65,7 +65,7 @@ AC_DEFUN([AX_COMPILER_FLAGS_LDFLAGS],[
         #
         # suggest-attribute=format is disabled because it gives too many false
         # positives
-        AX_APPEND_COMPILE_FLAGS([ dnl
+        AX_APPEND_LINK_FLAGS([ dnl
             -Wl,--fatal-warnings dnl
         ],ax_warn_ldflags_variable,[$ax_compiler_flags_test])
     ])


### PR DESCRIPTION
Not all compilers will verify the correctness of flags to the linker, so we need to explicitly use the linker when verifying flags.