### PR TITLE
AX_CXX_COMPILE_STDCXX_11: Support for Cray's crayCC compiler (CCE 8.4)

### DIFF
--- a/m4/ax_cxx_compile_stdcxx_11.m4
+++ b/m4/ax_cxx_compile_stdcxx_11.m4
@@ -35,7 +35,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 12
+#serial 13
 
 m4_define([_AX_CXX_COMPILE_STDCXX_11_testbody], [[
   template <typename T>
@@ -134,7 +134,8 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX_11], [dnl
   if test x$ac_success = xno; then
     dnl HP's aCC needs +std=c++11 according to:
     dnl http://h21007.www2.hp.com/portal/download/files/unprot/aCxx/PDF_Release_Notes/769149-001.pdf
-    for switch in -std=c++11 -std=c++0x +std=c++11; do
+    dnl Cray's crayCC needs "-h std=c++11"
+    for switch in -std=c++11 -std=c++0x +std=c++11 "-h std=c++11"; do
       cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx11_$switch])
       AC_CACHE_CHECK(whether $CXX supports C++11 features with $switch,
                      $cachevar,


### PR DESCRIPTION
Cray Compilation Environment 8.4 has full C++11 support through
"-h std=c++11" command line switch that we didn't test against