### PR TITLE
Push C language before testing HDF5 libraries.

### DIFF
--- a/m4/ax_lib_hdf5.m4
+++ b/m4/ax_lib_hdf5.m4
@@ -84,7 +84,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 11
+#serial 12
 
 AC_DEFUN([AX_LIB_HDF5], [
 
@@ -230,6 +230,7 @@ HDF5 support is being disabled (equivalent to --with-hdf5=no).
         AC_MSG_RESULT([yes (version $[HDF5_VERSION])])
 
         dnl See if we can compile
+        AC_LANG_PUSH([C])
         ax_lib_hdf5_save_CC=$CC
         ax_lib_hdf5_save_CPPFLAGS=$CPPFLAGS
         ax_lib_hdf5_save_LIBS=$LIBS
@@ -251,6 +252,7 @@ HDF5 support is being disabled (equivalent to --with-hdf5=no).
         CPPFLAGS=$ax_lib_hdf5_save_CPPFLAGS
         LIBS=$ax_lib_hdf5_save_LIBS
         LDFLAGS=$ax_lib_hdf5_save_LDFLAGS
+        AC_LANG_POP([C])
 
         AC_MSG_CHECKING([for matching HDF5 Fortran wrapper])
         dnl Presume HDF5 Fortran wrapper is just a name variant from H5CC


### PR DESCRIPTION
The test uses the C compiler wrapper, so tell autoconf that that should be the current language. Otherwise, you will get a warning if the current language is not C similar to:
```
configure.ac:237: warning: AC_LANG_PREPROC(Fortran): No preprocessor defined for Fortran
../../lib/autoconf/fortran.m4:245: AC_LANG_PREPROC(Fortran) is expanded from...
../../lib/autoconf/lang.m4:372: AC_LANG_PREPROC_REQUIRE is expanded from...
../../lib/autoconf/general.m4:2518: AC_PREPROC_IFELSE is expanded from...
../../lib/m4sugar/m4sh.m4:639: AS_IF is expanded from...
../../lib/m4sugar/m4sh.m4:385: AS_REQUIRE is expanded from...
../../lib/autoconf/general.m4:181: AC_REQUIRE_SHELL_FN is expanded from...
../../lib/autoconf/headers.m4:129: _AC_CHECK_HEADER_MONGREL is expanded from...
../../lib/autoconf/headers.m4:67: AC_CHECK_HEADER is expanded from...
/usr/share/aclocal/ax_lib_hdf5.m4:89: AX_LIB_HDF5 is expanded from...
```