### PR TITLE
Add 1.12 to list of lcov versions.

### DIFF
--- a/m4/ax_code_coverage.m4
+++ b/m4/ax_code_coverage.m4
@@ -67,7 +67,7 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-#serial 5
+#serial 6
 
 AC_DEFUN([AX_CODE_COVERAGE],[
 	dnl Check for --enable-code-coverage
@@ -104,7 +104,7 @@ AC_DEFUN([AX_CODE_COVERAGE],[
 		])
 
 		# List of supported lcov versions.
-		lcov_version_list="1.6 1.7 1.8 1.9 1.10 1.11"
+		lcov_version_list="1.6 1.7 1.8 1.9 1.10 1.11 1.12"
 
 		AC_CHECK_PROG([LCOV], [lcov], [lcov])
 		AC_CHECK_PROG([GENHTML], [genhtml], [genhtml])


### PR DESCRIPTION
This version is in Debian now and seems to work fine with the existing macros.