### PR TITLE
Fix second pass bug in _AX_WITH_CURSES_CHECKEXTRA

### DIFF
--- a/m4/ax_with_curses_extra.m4
+++ b/m4/ax_with_curses_extra.m4
@@ -144,7 +144,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 2
+#serial 3
 
 AC_DEFUN([_AX_WITH_CURSES_CHECKEXTRA], [
     dnl Parameter 1 is the variable name component, using uppercase letters only
@@ -173,7 +173,8 @@ AC_DEFUN([_AX_WITH_CURSES_CHECKEXTRA], [
         AC_DEFINE([_AX_WITH_CURSES_CHECKEXTRA_have_var],        [1], [Define to 1 if the Curses $2 library is present])
         AC_DEFINE([_AX_WITH_CURSES_CHECKEXTRA_have_header_var], [1], [Define to 1 if <$4> is present])
     ], [
-        _AX_WITH_CURSES_CHECKEXTRA_cv_var=no
+        AS_IF([test "x$[]_AX_WITH_CURSES_CHECKEXTRA_cv_var" = xyes], [],
+            [_AX_WITH_CURSES_CHECKEXTRA_cv_var=no])
     ])
     LIBS=$ax_saved_LIBS
 


### PR DESCRIPTION
Found bug where when _AX_WITH_CURSES_CHECKEXTRA is called a second time
on the same library, e.g. ncurses, the previous setting of
_AX_WITH_CURSES_CHECKEXTRA_cv_var to 'yes' would be changed to 'no' just
due to the tested header file not being available on the second pass.

This was found when AX_WITH_CURSES has 'with_ncurses' set to 'yes' and
'with_ncursesw' set to 'no' forcing _AX_WITH_CURSES_CHECKEXTRA to be
called twice in succession since ax_cv_curses_which is set to 'ncurses'
and the panel.h header file is tested as ncurses/panel.h and panel.h.

The system in question is OpenSuSE LEAP 42.1 which installs
/usr/include/ncurses/panel.h and not /usr/include/panel.h.