### PR TITLE
fix AX_GCC_X86_CPUID/AX_GCC_X86_CPUID_COUNT for 32-bit PIC compilations

### DIFF
--- a/m4/ax_gcc_x86_cpuid.m4
+++ b/m4/ax_gcc_x86_cpuid.m4
@@ -58,7 +58,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 8
+#serial 9
 
 AC_DEFUN([AX_GCC_X86_CPUID],
 [AX_GCC_X86_CPUID_COUNT($1, 0)
@@ -71,8 +71,10 @@ AC_CACHE_CHECK(for x86 cpuid $1 output, ax_cv_gcc_x86_cpuid_$1,
  [AC_RUN_IFELSE([AC_LANG_PROGRAM([#include <stdio.h>], [
      int op = $1, level = $2, eax, ebx, ecx, edx;
      FILE *f;
-      __asm__ __volatile__ ("cpuid"
-        : "=a" (eax), "=b" (ebx), "=c" (ecx), "=d" (edx)
+      __asm__ __volatile__ ("xchg %%ebx, %1\n"
+        "cpuid\n"
+        "xchg %%ebx, %1\n"
+        : "=a" (eax), "=r" (ebx), "=c" (ecx), "=d" (edx)
         : "a" (op), "2" (level));
 
      f = fopen("conftest_cpuid", "w"); if (!f) return 1;


### PR DESCRIPTION
The problem is that the EBX register cannot be used when position independent code is being generated.
The solutions to save and restore the EBX register.  See, e.g.:
  http://stackoverflow.com/questions/12221646/how-to-call-cpuid-instruction-in-a-mac-framework