### PR TITLE
Fix ax_boost_system for new versions of boost.

### DIFF
--- a/m4/ax_boost_system.m4
+++ b/m4/ax_boost_system.m4
@@ -31,7 +31,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 17
+#serial 18
 
 AC_DEFUN([AX_BOOST_SYSTEM],
 [
@@ -68,9 +68,10 @@ AC_DEFUN([AX_BOOST_SYSTEM],
 					   ax_cv_boost_system,
         [AC_LANG_PUSH([C++])
 			 CXXFLAGS_SAVE=$CXXFLAGS
+			 CXXFLAGS=
 
 			 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/system/error_code.hpp>]],
-                                   [[boost::system::system_category]])],
+				    [[boost::system::error_category *a = 0;]])],
                    ax_cv_boost_system=yes, ax_cv_boost_system=no)
 			 CXXFLAGS=$CXXFLAGS_SAVE
              AC_LANG_POP([C++])


### PR DESCRIPTION
Newer version of boost::system have a breaking change that makes
the test on ax_boost_system fail even though the library is
present.

Changed the test to use another construct that did not change. Also
reseted the "CXX_FLAG" to an empty value in case of it having a
"-Werror" that also makes the test break.

----

this update "works on my box" but I have limited ability to test on older versions of boost or with different flags combinations.
