### PR TITLE
Add GJS macros

### DIFF
--- a/m4/ax_check_gir_symbols_gjs.m4
+++ b/m4/ax_check_gir_symbols_gjs.m4
@@ -1,0 +1,83 @@
+# ============================================================================
+#  http://www.gnu.org/software/autoconf-archive/ax_check_gir_symbols_gjs.html
+# ============================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_GIR_SYMBOLS_GJS(MODULE, APIVERSION, SYMBOLS)
+#
+# DESCRIPTION
+#
+#   Check that each symbol from the whitespace-separated list of $SYMBOLS is
+#   defined inside the GObject Introspection module $MODULE with API version
+#   $APIVERSION, and is importable in GJS, GNOME's JavaScript engine
+#   (https://wiki.gnome.org/Projects/Gjs).
+#
+#   GObject Introspection
+#   (https://wiki.gnome.org/Projects/GObjectIntrospection) is a tool for
+#   generating bindings from C libraries to higher-level languages. The
+#   bindings live in a GObject Introspection repository (GIR) file, which is
+#   what this macro checks.
+#
+#   Note that for the purposes of GObject Introspection, the API version is
+#   different from the release version. For example, GTK currently has API
+#   version 3.0, but that could mean any release from the 3.0, 3.2, 3.4,...
+#   series.
+#
+#   Example:
+#
+#     AX_CHECK_GIR_SYMBOLS_GJS([Gtk], [3.0], [ListBox FlowBox
+#                                             Widget.get_action_group])
+#
+#   NOTE: This macro depends on AX_PROG_GJS.
+#
+# LICENSE
+#
+#   Copyright (c) 2013, 2016 Endless Mobile, Inc.; contributed by Philip Chimento <philip@endlessm.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 1
+
+AC_DEFUN([AX_CHECK_GIR_SYMBOLS_GJS], [
+  AC_REQUIRE([AX_PROG_GJS])
+  m4_foreach_w([SYMBOL], [$3], [
+    AC_MSG_CHECKING([for $1.SYMBOL in $1-$2])
+    _AX_GJS_IFELSE([
+      imports.gi.versions@<:@\"$1\"@:>@ = \"$2\";
+      const Library = imports.gi.$1;
+      let symbols = \"SYMBOL\".split('.');
+      function check_symbols(symbols_list) {
+        printerr('gjs: checking', symbols_list.join('.'));
+        try {
+          symbols_list.reduce(function (prev, curr) {
+            if (typeof prev@<:@curr@:>@ === 'undefined')
+              throw 1;
+            return prev@<:@curr@:>@;
+          }, Library);
+          return true;
+        } catch (e) {
+          if (e === 1)
+            return false;
+          throw e;
+        }
+      }
+      if (!check_symbols(symbols)) {
+        dnl For methods, we need to check the class's prototype
+        symbols.splice(-1, 0, 'prototype');
+        if (!check_symbols(symbols))
+          throw 1;
+      }
+    ],
+    [AC_MSG_RESULT([yes])],
+    [
+      AC_MSG_RESULT([no])
+      AC_MSG_ERROR([The symbol $1.SYMBOL was not importable
+in GJS, although the $1 library was present.
+Perhaps you need a newer version of the library?])
+    ])
+  ])
+])

--- a/m4/ax_check_girs_gjs.m4
+++ b/m4/ax_check_girs_gjs.m4
@@ -1,0 +1,68 @@
+# ===========================================================================
+#     http://www.gnu.org/software/autoconf-archive/ax_check_girs_gjs.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_GIRS_GJS(MODULE, API_VERSION [, MODULE, API_VERSION...])
+#
+# DESCRIPTION
+#
+#   Check that the GObject Introspection module $MODULE is importable in GJS
+#   (GNOME's JavaScript engine, https://wiki.gnome.org/Projects/Gjs). The
+#   API version must be $API_VERSION.
+#
+#   GObject Introspection
+#   (https://wiki.gnome.org/Projects/GObjectIntrospection) is a tool for
+#   generating bindings from C libraries to higher-level languages. The
+#   bindings live in a GObject Introspection repository (GIR) file, which is
+#   what this macro checks.
+#
+#   Note that for the purposes of GObject Introspection, the API version is
+#   different from the release version. For example, GTK currently has API
+#   version 3.0, but that could mean any release from the 3.0, 3.2, 3.4,...
+#   series. To check for specific API that was added in a later version, use
+#   AX_CHECK_GIR_SYMBOLS_GJS.
+#
+#   Example:
+#
+#     AX_CHECK_GIRS_GJS([Gdk], [3.0],
+#                       [Gtk], [3.0])
+#
+#   NOTE: This macro depends on AX_PROG_GJS.
+#
+# LICENSE
+#
+#   Copyright (c) 2013, 2016 Endless Mobile, Inc.; contributed by Philip Chimento <philip@endlessm.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 1
+
+AC_DEFUN([_AX_CHECK_GIR_GJS], [
+  AC_MSG_CHECKING([for version $2 of $1])
+  _AX_GJS_IFELSE([
+      imports.gi.versions@<:@\"$1\"@:>@ = \"$2\";
+      const Library = imports.gi.$1;
+    ],
+    [AC_MSG_RESULT([yes])],
+    [
+      AC_MSG_RESULT([no])
+      AC_MSG_ERROR([You do not have at least API version $2 of
+the GObject Introspection bindings for the $1 library.
+Build a version from source, or find out what package to
+install with one of these commands, depending on your system:
+  apt-file search $1-$2.typelib
+  dnf provides \*/$1-$2.typelib
+])
+    ]
+  )
+])
+
+AC_DEFUN([AX_CHECK_GIRS_GJS], [
+  AC_REQUIRE([AX_PROG_GJS])
+  m4_map_args_pair([_AX_CHECK_GIR_GJS], [AC_MSG_ERROR], $@)
+])

--- a/m4/ax_prog_gjs.m4
+++ b/m4/ax_prog_gjs.m4
@@ -1,0 +1,48 @@
+# ===========================================================================
+#        http://www.gnu.org/software/autoconf-archive/ax_prog_gjs.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PROG_GJS
+#
+# DESCRIPTION
+#
+#   AX_PROG_GJS checks for the presence of the JavaScript interpreter GJS
+#   (https://wiki.gnome.org/Projects/Gjs) in the path. If it is not found,
+#   an error is issued and configure is halted. If it is found, the path of
+#   the interpreter is placed into a variable named GJS, which is declared
+#   precious.
+#
+# LICENSE
+#
+#   Copyright (c) 2013, 2016 Endless Mobile, Inc.; contributed by Philip Chimento <philip@endlessm.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 1
+
+AC_DEFUN_ONCE([AX_PROG_GJS], [
+  AC_ARG_VAR([GJS], [Path to GJS interpreter])
+  AC_PATH_PROG([GJS], [gjs], [notfound])
+  AS_IF([test "x$GJS" = "xnotfound"],
+    [AC_MSG_ERROR([GJS is required, but was not found. If GJS is
+installed, try passing its path in an environment variable,
+for example GJS=/path/to/gjs.])])
+])
+
+# _AX_GJS_IFELSE(program, [action-if-true], [action-if-false])
+# -------------------------------------------------------------
+# Comparable to AC_RUN_IFELSE(), but runs the program using GJS
+# instead of trying to compile it and link it.
+# Used by AX_CHECK_GIRS_GJS and AX_CHECK_GIR_SYMBOLS_GJS.
+
+AC_DEFUN([_AX_GJS_IFELSE], [
+  AC_REQUIRE([AX_PROG_GJS])
+  echo "$1" >conftest.js
+  $GJS conftest.js >>config.log 2>&1
+  AS_IF([test $? -eq 0], [$2], [$3])
+])


### PR DESCRIPTION
This adds three macros to the library:

AX_PROG_GJS - Check for the GJS JavaScript interpreter
AX_CHECK_GIRS_GJS - Check for importability of GObject introspection
   module(s) in GJS
AX_CHECK_GIR_SYMBOLS_GJS - Check for the presence of particular symbols
   in a GObject introspection module imported into GJS