### PR TITLE
AX_PROG_DOXYGEN: quote DX_RULES

### DIFF
--- a/m4/ax_prog_doxygen.m4
+++ b/m4/ax_prog_doxygen.m4
@@ -97,7 +97,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 18
+#serial 19
 
 ## ----------##
 ## Defaults. ##
@@ -378,94 +378,82 @@ a4wide|a4|letter|legal|executive)
 esac
 
 # Rules:
-if test $DX_FLAG_html -eq 1; then
-    DX_SNIPPET_html="## ------------------------------- ##
+AS_IF([[test $DX_FLAG_html -eq 1]],
+[[DX_SNIPPET_html="## ------------------------------- ##
 ## Rules specific for HTML output. ##
 ## ------------------------------- ##
 
-DX_CLEAN_HTML = \$(DX_DOCDIR)/html[]dnl
+DX_CLEAN_HTML = \$(DX_DOCDIR)/html]dnl
 m4_foreach([DX_i], [m4_shift(DX_loop)], [[\\
-                \$(DX_DOCDIR]DX_i[)/html]])
+                \$(DX_DOCDIR]DX_i[)/html]])[
 
-"
-else
-    DX_SNIPPET_html=""
-fi
-if test $DX_FLAG_chi -eq 1; then
-    DX_SNIPPET_chi="
-DX_CLEAN_CHI = \$(DX_DOCDIR)/\$(PACKAGE).chi[]dnl
+"]],
+[[DX_SNIPPET_html=""]])
+AS_IF([[test $DX_FLAG_chi -eq 1]],
+[[DX_SNIPPET_chi="
+DX_CLEAN_CHI = \$(DX_DOCDIR)/\$(PACKAGE).chi]dnl
 m4_foreach([DX_i], [m4_shift(DX_loop)], [[\\
-               \$(DX_DOCDIR]DX_i[)/\$(PACKAGE).chi]])"
-else
-    DX_SNIPPET_chi=""
-fi
-if test $DX_FLAG_chm -eq 1; then
-    DX_SNIPPET_chm="## ------------------------------ ##
+               \$(DX_DOCDIR]DX_i[)/\$(PACKAGE).chi]])["]],
+[[DX_SNIPPET_chi=""]])
+AS_IF([[test $DX_FLAG_chm -eq 1]],
+[[DX_SNIPPET_chm="## ------------------------------ ##
 ## Rules specific for CHM output. ##
 ## ------------------------------ ##
 
-DX_CLEAN_CHM = \$(DX_DOCDIR)/chm[]dnl
+DX_CLEAN_CHM = \$(DX_DOCDIR)/chm]dnl
 m4_foreach([DX_i], [m4_shift(DX_loop)], [[\\
-               \$(DX_DOCDIR]DX_i[)/chm]])\
+               \$(DX_DOCDIR]DX_i[)/chm]])[\
 ${DX_SNIPPET_chi}
 
-"
-else
-    DX_SNIPPET_chm=""
-fi
-if test $DX_FLAG_man -eq 1; then
-    DX_SNIPPET_man="## ------------------------------ ##
+"]],
+[[DX_SNIPPET_chm=""]])
+AS_IF([[test $DX_FLAG_man -eq 1]],
+[[DX_SNIPPET_man="## ------------------------------ ##
 ## Rules specific for MAN output. ##
 ## ------------------------------ ##
 
-DX_CLEAN_MAN = \$(DX_DOCDIR)/man[]dnl
+DX_CLEAN_MAN = \$(DX_DOCDIR)/man]dnl
 m4_foreach([DX_i], [m4_shift(DX_loop)], [[\\
-               \$(DX_DOCDIR]DX_i[)/man]])
+               \$(DX_DOCDIR]DX_i[)/man]])[
 
-"
-else
-    DX_SNIPPET_man=""
-fi
-if test $DX_FLAG_rtf -eq 1; then
-    DX_SNIPPET_rtf="## ------------------------------ ##
+"]],
+[[DX_SNIPPET_man=""]])
+AS_IF([[test $DX_FLAG_rtf -eq 1]],
+[[DX_SNIPPET_rtf="## ------------------------------ ##
 ## Rules specific for RTF output. ##
 ## ------------------------------ ##
 
-DX_CLEAN_RTF = \$(DX_DOCDIR)/rtf[]dnl
+DX_CLEAN_RTF = \$(DX_DOCDIR)/rtf]dnl
 m4_foreach([DX_i], [m4_shift(DX_loop)], [[\\
-               \$(DX_DOCDIR]DX_i[)/rtf]])
+               \$(DX_DOCDIR]DX_i[)/rtf]])[
 
-"
-else
-    DX_SNIPPET_rtf=""
-fi
-if test $DX_FLAG_xml -eq 1; then
-    DX_SNIPPET_xml="## ------------------------------ ##
+"]],
+[[DX_SNIPPET_rtf=""]])
+AS_IF([[test $DX_FLAG_xml -eq 1]],
+[[DX_SNIPPET_xml="## ------------------------------ ##
 ## Rules specific for XML output. ##
 ## ------------------------------ ##
 
-DX_CLEAN_XML = \$(DX_DOCDIR)/xml[]dnl
+DX_CLEAN_XML = \$(DX_DOCDIR)/xml]dnl
 m4_foreach([DX_i], [m4_shift(DX_loop)], [[\\
-               \$(DX_DOCDIR]DX_i[)/xml]])
+               \$(DX_DOCDIR]DX_i[)/xml]])[
 
-"
-else
-    DX_SNIPPET_xml=""
-fi
-if test $DX_FLAG_ps -eq 1; then
-    DX_SNIPPET_ps="## ----------------------------- ##
+"]],
+[[DX_SNIPPET_xml=""]])
+AS_IF([[test $DX_FLAG_ps -eq 1]],
+[[DX_SNIPPET_ps="## ----------------------------- ##
 ## Rules specific for PS output. ##
 ## ----------------------------- ##
 
-DX_CLEAN_PS = \$(DX_DOCDIR)/\$(PACKAGE).ps[]dnl
+DX_CLEAN_PS = \$(DX_DOCDIR)/\$(PACKAGE).ps]dnl
 m4_foreach([DX_i], [m4_shift(DX_loop)], [[\\
-              \$(DX_DOCDIR]DX_i[)/\$(PACKAGE).ps]])
+              \$(DX_DOCDIR]DX_i[)/\$(PACKAGE).ps]])[
 
 DX_PS_GOAL = doxygen-ps
 
 doxygen-ps: \$(DX_CLEAN_PS)
 
-m4_foreach([DX_i], [DX_loop],
+]m4_foreach([DX_i], [DX_loop],
 [[\$(DX_DOCDIR]DX_i[)/\$(PACKAGE).ps: \$(DX_DOCDIR]DX_i[)/\$(PACKAGE).tag
 	\$(DX_V_LATEX)cd \$(DX_DOCDIR]DX_i[)/latex; \\
 	rm -f *.aux *.toc *.idx *.ind *.ilg *.log *.out; \\
@@ -481,25 +469,22 @@ m4_foreach([DX_i], [DX_loop],
 	done; \\
 	\$(DX_DVIPS) -o ../\$(PACKAGE).ps refman.dvi
 
-]])dnl
-"
-else
-    DX_SNIPPET_ps=""
-fi
-if test $DX_FLAG_pdf -eq 1; then
-    DX_SNIPPET_pdf="## ------------------------------ ##
+]])["]],
+[[DX_SNIPPET_ps=""]])
+AS_IF([[test $DX_FLAG_pdf -eq 1]],
+[[DX_SNIPPET_pdf="## ------------------------------ ##
 ## Rules specific for PDF output. ##
 ## ------------------------------ ##
 
-DX_CLEAN_PDF = \$(DX_DOCDIR)/\$(PACKAGE).pdf[]dnl
+DX_CLEAN_PDF = \$(DX_DOCDIR)/\$(PACKAGE).pdf]dnl
 m4_foreach([DX_i], [m4_shift(DX_loop)], [[\\
-               \$(DX_DOCDIR]DX_i[)/\$(PACKAGE).pdf]])
+               \$(DX_DOCDIR]DX_i[)/\$(PACKAGE).pdf]])[
 
 DX_PDF_GOAL = doxygen-pdf
 
 doxygen-pdf: \$(DX_CLEAN_PDF)
 
-m4_foreach([DX_i], [DX_loop],
+]m4_foreach([DX_i], [DX_loop],
 [[\$(DX_DOCDIR]DX_i[)/\$(PACKAGE).pdf: \$(DX_DOCDIR]DX_i[)/\$(PACKAGE).tag
 	\$(DX_V_LATEX)cd \$(DX_DOCDIR]DX_i[)/latex; \\
 	rm -f *.aux *.toc *.idx *.ind *.ilg *.log *.out; \\
@@ -515,31 +500,26 @@ m4_foreach([DX_i], [DX_loop],
 	done; \\
 	mv refman.pdf ../\$(PACKAGE).pdf
 
-]])dnl
-"
-else
-    DX_SNIPPET_pdf=""
-fi
-if test $DX_FLAG_ps -eq 1 -o $DX_FLAG_pdf -eq 1; then
-    DX_SNIPPET_latex="## ------------------------------------------------- ##
+]])["]],
+[[DX_SNIPPET_pdf=""]])
+AS_IF([[test $DX_FLAG_ps -eq 1 -o $DX_FLAG_pdf -eq 1]],
+[[DX_SNIPPET_latex="## ------------------------------------------------- ##
 ## Rules specific for LaTeX (shared for PS and PDF). ##
 ## ------------------------------------------------- ##
 
 DX_V_LATEX = \$(_DX_v_LATEX_\$(V))
 _DX_v_LATEX_ = \$(_DX_v_LATEX_\$(AM_DEFAULT_VERBOSITY))
-_DX_v_LATEX_0 = @echo \"  LATEX \" \$[]][[]@;
+_DX_v_LATEX_0 = @echo \"  LATEX \" \$][@;
 
-DX_CLEAN_LATEX = \$(DX_DOCDIR)/latex[]dnl
+DX_CLEAN_LATEX = \$(DX_DOCDIR)/latex]dnl
 m4_foreach([DX_i], [m4_shift(DX_loop)], [[\\
-                 \$(DX_DOCDIR]DX_i[)/latex]])
+                 \$(DX_DOCDIR]DX_i[)/latex]])[
 
-"
-else
-    DX_SNIPPET_latex=""
-fi
+"]],
+[[DX_SNIPPET_latex=""]])
 
-if test $DX_FLAG_doc -eq 1; then
-    DX_SNIPPET_doc="## --------------------------------- ##
+AS_IF([[test $DX_FLAG_doc -eq 1]],
+[[DX_SNIPPET_doc="## --------------------------------- ##
 ## Format-independent Doxygen rules. ##
 ## --------------------------------- ##
 
@@ -559,23 +539,23 @@ _DX_v_DXGEN_0 = @echo \"  DXGEN \" \$<;
 
 .INTERMEDIATE: doxygen-run \$(DX_PS_GOAL) \$(DX_PDF_GOAL)
 
-doxygen-run:[]m4_foreach([DX_i], [DX_loop],
-                         [[ \$(DX_DOCDIR]DX_i[)/\$(PACKAGE).tag]])
+doxygen-run:]m4_foreach([DX_i], [DX_loop],
+                         [[ \$(DX_DOCDIR]DX_i[)/\$(PACKAGE).tag]])[
 
 doxygen-doc: doxygen-run \$(DX_PS_GOAL) \$(DX_PDF_GOAL)
 
-m4_foreach([DX_i], [DX_loop],
+]m4_foreach([DX_i], [DX_loop],
 [[\$(DX_DOCDIR]DX_i[)/\$(PACKAGE).tag: \$(DX_CONFIG]DX_i[) \$(pkginclude_HEADERS)
 	\$(A""M_V_at)rm -rf \$(DX_DOCDIR]DX_i[)
 	\$(DX_V_DXGEN)\$(DX_ENV) DOCDIR=\$(DX_DOCDIR]DX_i[) \$(DX_DOXYGEN) \$(DX_CONFIG]DX_i[)
 	\$(A""M_V_at)echo Timestamp >\$][@
 
 ]])dnl
-DX_CLEANFILES = \\
+[DX_CLEANFILES = \\]
 m4_foreach([DX_i], [DX_loop],
 [[	\$(DX_DOCDIR]DX_i[)/\$(PACKAGE).tag \\
 ]])dnl
-	-r \\
+[	-r \\
 	\$(DX_CLEAN_HTML) \\
 	\$(DX_CLEAN_CHM) \\
 	\$(DX_CLEAN_CHI) \\
@@ -584,10 +564,8 @@ m4_foreach([DX_i], [DX_loop],
 	\$(DX_CLEAN_XML) \\
 	\$(DX_CLEAN_PS) \\
 	\$(DX_CLEAN_PDF) \\
-	\$(DX_CLEAN_LATEX)"
-else
-    DX_SNIPPET_doc=""
-fi
+	\$(DX_CLEAN_LATEX)"]],
+[[DX_SNIPPET_doc=""]])
 AC_SUBST([DX_RULES],
 ["${DX_SNIPPET_doc}"])dnl
 AM_SUBST_NOTMAKE([DX_RULES])


### PR DESCRIPTION
Quote the DX_RULES assignment to prevent some other M4 macro from modifying the text. Also transition from direct if-statements to AS_IF for the same reasons: to prevent undesired macro replacements.

This contains the following Savannah patch:
* [AX_PROG_DOXYGEN: quote DX_RULES](https://savannah.gnu.org/patch/?8929)