### PR TITLE
3 patches for valgrind check

### DIFF
--- a/m4/ax_valgrind_check.m4
+++ b/m4/ax_valgrind_check.m4
@@ -55,7 +55,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AC_DEFUN([AX_VALGRIND_CHECK],[
 	dnl Check for --enable-valgrind
@@ -98,7 +98,7 @@ AC_DEFUN([AX_VALGRIND_CHECK],[
 		])
 	])
 
-VALGRIND_CHECK_RULES='
+[VALGRIND_CHECK_RULES='
 # Valgrind check
 #
 # Optional:
@@ -178,7 +178,7 @@ MOSTLYCLEANFILES ?=
 MOSTLYCLEANFILES += $(valgrind_log_files)
 
 .PHONY: check-valgrind check-valgrind-tool
-'
+']
 
 	AC_SUBST([VALGRIND_CHECK_RULES])
 	m4_ifdef([_AM_SUBST_NOTMAKE], [_AM_SUBST_NOTMAKE([VALGRIND_CHECK_RULES])])

--- a/m4/ax_valgrind_check.m4
+++ b/m4/ax_valgrind_check.m4
@@ -55,7 +55,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 6
+#serial 7
 
 AC_DEFUN([AX_VALGRIND_CHECK],[
 	dnl Check for --enable-valgrind
@@ -63,13 +63,19 @@ AC_DEFUN([AX_VALGRIND_CHECK],[
 	              [AS_HELP_STRING([--enable-valgrind], [Whether to enable Valgrind on the unit tests])],
 	              [enable_valgrind=$enableval],[enable_valgrind=])
 
-	# Check for Valgrind.
-	AC_CHECK_PROG([VALGRIND],[valgrind],[valgrind])
-
-	AS_IF([test "$enable_valgrind" = "yes" -a "$VALGRIND" = ""],[
-		AC_MSG_ERROR([Could not find valgrind; either install it or reconfigure with --disable-valgrind])
+	AS_IF([test "$enable_valgrind" != "no"],[
+		# Check for Valgrind.
+		AC_CHECK_PROG([VALGRIND],[valgrind],[valgrind])
+		AS_IF([test "$VALGRIND" = ""],[
+			AS_IF([test "$enable_valgrind" = "yes"],[
+				AC_MSG_ERROR([Could not find valgrind; either install it or reconfigure with --disable-valgrind])
+			],[
+				enable_valgrind=no
+			])
+		],[
+			enable_valgrind=yes
+		])
 	])
-	AS_IF([test "$enable_valgrind" != "no"],[enable_valgrind=yes])
 
 	AM_CONDITIONAL([VALGRIND_ENABLED],[test "$enable_valgrind" = "yes"])
 	AC_SUBST([VALGRIND_ENABLED],[$enable_valgrind])

--- a/m4/ax_valgrind_check.m4
+++ b/m4/ax_valgrind_check.m4
@@ -55,11 +55,10 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 5
+#serial 6
 
 AC_DEFUN([AX_VALGRIND_CHECK],[
 	dnl Check for --enable-valgrind
-	AC_MSG_CHECKING([whether to enable Valgrind on the unit tests])
 	AC_ARG_ENABLE([valgrind],
 	              [AS_HELP_STRING([--enable-valgrind], [Whether to enable Valgrind on the unit tests])],
 	              [enable_valgrind=$enableval],[enable_valgrind=])
@@ -74,7 +73,6 @@ AC_DEFUN([AX_VALGRIND_CHECK],[
 
 	AM_CONDITIONAL([VALGRIND_ENABLED],[test "$enable_valgrind" = "yes"])
 	AC_SUBST([VALGRIND_ENABLED],[$enable_valgrind])
-	AC_MSG_RESULT([$enable_valgrind])
 
 	# Check for Valgrind tools we care about.
 	m4_define([valgrind_tool_list],[[memcheck], [helgrind], [drd], [exp-sgcheck]])


### PR DESCRIPTION
This contains the following Savannah patches:
* [AX_VALGRIND_CHECK: clean up configure message](https://savannah.gnu.org/patch/?8930)
* [AX_VALGRIND_CHECK: fix logic around AC_CHECK_PROG](https://savannah.gnu.org/patch/?8931)
* [AX_VALGRIND_CHECK: quote VALGRIND_CHECK_RULES](https://savannah.gnu.org/patch/?8932)