### PR TITLE
Update CXXCPP after updating CXX.

### DIFF
--- a/m4/ax_cxx_compile_stdcxx.m4
+++ b/m4/ax_cxx_compile_stdcxx.m4
@@ -9,9 +9,9 @@
 # DESCRIPTION
 #
 #   Check for baseline language coverage in the compiler for the specified
-#   version of the C++ standard.  If necessary, add switches to CXX to
-#   enable support.  VERSION may be '11' (for the C++11 standard) or '14'
-#   (for the C++14 standard).
+#   version of the C++ standard.  If necessary, add switches to CXX and
+#   CXXCPP to enable support.  VERSION may be '11' (for the C++11 standard)
+#   or '14' (for the C++14 standard).
 #
 #   The second argument, if specified, indicates whether you insist on an
 #   extended mode (e.g. -std=gnu++11) or a strict conformance mode (e.g.
@@ -39,7 +39,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 3
+#serial 4
 
 dnl  This macro is based on the code from the AX_CXX_COMPILE_STDCXX_11 macro
 dnl  (serial version number 13).
@@ -82,6 +82,9 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
          CXX="$ac_save_CXX"])
       if eval test x\$$cachevar = xyes; then
         CXX="$CXX $switch"
+        if test -n "$CXXCPP" ; then
+          CXXCPP="$CXXCPP $switch"
+        fi
         ac_success=yes
         break
       fi
@@ -105,6 +108,9 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
          CXX="$ac_save_CXX"])
       if eval test x\$$cachevar = xyes; then
         CXX="$CXX $switch"
+        if test -n "$CXXCPP" ; then
+          CXXCPP="$CXXCPP $switch"
+        fi
         ac_success=yes
         break
       fi

--- a/m4/ax_cxx_compile_stdcxx_11.m4
+++ b/m4/ax_cxx_compile_stdcxx_11.m4
@@ -9,7 +9,8 @@
 # DESCRIPTION
 #
 #   Check for baseline language coverage in the compiler for the C++11
-#   standard; if necessary, add switches to CXX to enable support.
+#   standard; if necessary, add switches to CXX and CXXCPP to enable
+#   support.
 #
 #   This macro is a convenience alias for calling the AX_CXX_COMPILE_STDCXX
 #   macro with the version set to C++11.  The two optional arguments are
@@ -32,7 +33,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 15
+#serial 16
 
 include([ax_cxx_compile_stdcxx.m4])
 

--- a/m4/ax_cxx_compile_stdcxx_14.m4
+++ b/m4/ax_cxx_compile_stdcxx_14.m4
@@ -9,7 +9,8 @@
 # DESCRIPTION
 #
 #   Check for baseline language coverage in the compiler for the C++14
-#   standard; if necessary, add switches to CXX to enable support.
+#   standard; if necessary, add switches to CXX and CXXCPP to enable
+#   support.
 #
 #   This macro is a convenience alias for calling the AX_CXX_COMPILE_STDCXX
 #   macro with the version set to C++14.  The two optional arguments are
@@ -27,7 +28,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 2
+#serial 3
 
 include([ax_cxx_compile_stdcxx.m4])
 


### PR DESCRIPTION
I'm currently facing this issue: I'm using the `AX_CXX_COMPILE_STDCXX_11` macro (which in turn uses `AX_CXX_COMPILE_STDCXX`) to check for C++11 compiler support.  If C++11 compiler support is detected, this macro sets `CXX` by appending the relevant switch:

```
CXX="$CXX $switch"
```

So far, so good.  Problem is, other variables are evaluated in an earlier stage from `CXX`, such as `CXXCPP` in `AC_PROG_CXXCPP`:

```
[...snip...]
if test -z "$CXXCPP"; then
  AC_CACHE_VAL(ac_cv_prog_CXXCPP,
  [dnl

    # Double quotes because CXXCPP needs to be expanded

    for CXXCPP in "$CXX -E" "/lib/cpp"
    do
      _AC_PROG_PREPROC_WORKS_IFELSE([break])
    done
    ac_cv_prog_CXXCPP=$CXXCPP
  ])dnl

  CXXCPP=$ac_cv_prog_CXXCPP
else
  ac_cv_prog_CXXCPP=$CXXCPP
fi
[...snip...]
```

After a macro sets `CXX` (such as `AX_CXX_COMPILE_STDCXX_11` does), I found no (clean) way to have Autoconf re-evaluate `CXXCPP` again (the check is cached, and anyway calling `AC_PROG_CXXCPP` manually wouldn't be transparent even if it worked).

I think anybody that requests the compiler to be checked and configured to support a certain C++ standard expects the preprocessor to be configured as well.  I you don't, macros such `AC_CHECK_HEADER` wouldn't detect correctly the configuration of the current build and emit warning similar to these one:

```
checking atomic usability... yes
checking atomic presence... no
configure: WARNING: atomic: accepted by the compiler, rejected by the preprocessor!
configure: WARNING: atomic: proceeding with the compiler's result
```

I've patched the aforementioned macros so that they append the same switch to `CXXCPP` after setting `CXX`:

```
CXX="$CXX $switch"
# Warning: /lib/cpp is not being checked (as AC_PROG_CXXCPP does).
if test -n "$CXXCPP" ; then
  CXXCPP="$CXXCPP $switch"
fi
```

I'd rather invoke `AC_PROG_CXXCPP` in order not to duplicate code that manages this kind of variable inter-dependency in multiple places as in:

```
CXX="$CXX $switch"
AC_PROG_CXXCPP
```

but that call it has no effect because the result is cached and not re-evaluated.  Another idea could be cleaning the variables used by AC_PROG_CXXCPP to force re-evaluation but that would be another hack, since you're again coupling a macro with another one and in an even worse way (since you're relying on another macro's internals)

I sent a mail to the Autoconf mailing list but I haven't heard from anybody yet.  Since C++ standards support checks are being integrated into Autoconf, these macros will soon be obsolete and nobody's really caring about them.  However, I thought a patch would be useful.  This has been tested with `g++` and `clang++` on FreeBSD, Debian, Ubuntu, SmartOS, Mac OS X and Cygwin and I found no situations in which setting the preprocessor breaks in any way.