### PR TITLE
AX_VALGRIND_CHECK: total of four patches

### DIFF
--- a/m4/ax_valgrind_check.m4
+++ b/m4/ax_valgrind_check.m4
@@ -59,7 +59,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 9
+#serial 10
 
 AC_DEFUN([AX_VALGRIND_CHECK],[
 	dnl Check for --enable-valgrind
@@ -146,7 +146,7 @@ check-valgrind:
 ifeq ($(VALGRIND_ENABLED),yes)
 	-$(foreach tool,$(valgrind_tools), \
 		$(if $(VALGRIND_HAVE_TOOL_$(tool))$(VALGRIND_HAVE_TOOL_exp_$(tool)), \
-			$(MAKE) $(AM_MAKEFLAGS) -k check-valgrind-tool VALGRIND_TOOL=$(tool); \
+			$(MAKE) $(AM_MAKEFLAGS) -k check-valgrind-$(tool); \
 		) \
 	)
 else
@@ -164,60 +164,23 @@ VALGRIND_LOG_COMPILER = \
 	$(valgrind_lt) \
 	$(VALGRIND) $(VALGRIND_SUPPRESSIONS) --error-exitcode=1 $(VALGRIND_FLAGS)
 
-check-valgrind-tool:
 ifeq ($(VALGRIND_ENABLED),yes)
-	$(MAKE) check-TESTS \
-		TESTS_ENVIRONMENT="$(VALGRIND_TESTS_ENVIRONMENT)" \
-		LOG_COMPILER="$(VALGRIND_LOG_COMPILER)" \
-		LOG_FLAGS="$(valgrind_$(VALGRIND_TOOL)_flags)" \
-		TEST_SUITE_LOG=test-suite-$(VALGRIND_TOOL).log
+define valgrind_tool_rule =
+check-valgrind-$(1):
+	$$(MAKE) check-TESTS \
+		TESTS_ENVIRONMENT="$$(VALGRIND_TESTS_ENVIRONMENT)" \
+		LOG_COMPILER="$$(VALGRIND_LOG_COMPILER)" \
+		LOG_FLAGS="$$(valgrind_$(1)_flags)" \
+		TEST_SUITE_LOG=test-suite-$(1).log
+endef
 else
+define valgrind_tool_rule =
+check-valgrind-$(1):
 	@echo "Need to reconfigure with --enable-valgrind"
+endef
 endif
 
-check-valgrind-memcheck:
-ifeq ($(VALGRIND_ENABLED),yes)
-	$(MAKE) check-TESTS \
-		TESTS_ENVIRONMENT="$(VALGRIND_TESTS_ENVIRONMENT)" \
-		LOG_COMPILER="$(VALGRIND_LOG_COMPILER)" \
-		LOG_FLAGS="$(valgrind_memcheck_flags)" \
-		TEST_SUITE_LOG=test-suite-memcheck.log
-else
-	@echo "Need to reconfigure with --enable-valgrind"
-endif
-
-check-valgrind-helgrind:
-ifeq ($(VALGRIND_ENABLED),yes)
-	$(MAKE) check-TESTS \
-		TESTS_ENVIRONMENT="$(VALGRIND_TESTS_ENVIRONMENT)" \
-		LOG_COMPILER="$(VALGRIND_LOG_COMPILER)" \
-		LOG_FLAGS="$(valgrind_helgrind_flags)" \
-		TEST_SUITE_LOG=test-suite-helgrind.log
-else
-	@echo "Need to reconfigure with --enable-valgrind"
-endif
-
-check-valgrind-drd:
-ifeq ($(VALGRIND_ENABLED),yes)
-	$(MAKE) check-TESTS \
-		TESTS_ENVIRONMENT="$(VALGRIND_TESTS_ENVIRONMENT)" \
-		LOG_COMPILER="$(VALGRIND_LOG_COMPILER)" \
-		LOG_FLAGS="$(valgrind_drd_flags)" \
-		TEST_SUITE_LOG=test-suite-drd.log
-else
-	@echo "Need to reconfigure with --enable-valgrind"
-endif
-
-check-valgrind-sgcheck:
-ifeq ($(VALGRIND_ENABLED),yes)
-	$(MAKE) check-TESTS \
-		TESTS_ENVIRONMENT="$(VALGRIND_TESTS_ENVIRONMENT)" \
-		LOG_COMPILER="$(VALGRIND_LOG_COMPILER)" \
-		LOG_FLAGS="$(valgrind_sgcheck_flags)" \
-		TEST_SUITE_LOG=test-suite-sgcheck.log
-else
-	@echo "Need to reconfigure with --enable-valgrind"
-endif
+$(foreach tool,$(valgrind_tools),$(eval $(call valgrind_tool_rule,$(tool))))
 
 A''M_DISTCHECK_CONFIGURE_FLAGS ?=
 A''M_DISTCHECK_CONFIGURE_FLAGS += --disable-valgrind
@@ -225,7 +188,7 @@ A''M_DISTCHECK_CONFIGURE_FLAGS += --disable-valgrind
 MOSTLYCLEANFILES ?=
 MOSTLYCLEANFILES += $(valgrind_log_files)
 
-.PHONY: check-valgrind check-valgrind-tool
+.PHONY: check-valgrind $(add-prefix check-valgrind-,$(valgrind_tools))
 ']
 
 	AC_SUBST([VALGRIND_CHECK_RULES])

--- a/m4/ax_valgrind_check.m4
+++ b/m4/ax_valgrind_check.m4
@@ -59,7 +59,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 10
+#serial 11
 
 AC_DEFUN([AX_VALGRIND_CHECK],[
 	dnl Check for --enable-valgrind
@@ -133,6 +133,9 @@ valgrind_sgcheck_flags = --tool=exp-sgcheck $(VALGRIND_sgcheck_FLAGS)
 valgrind_quiet = $(valgrind_quiet_$(V))
 valgrind_quiet_ = $(valgrind_quiet_$(AM_DEFAULT_VERBOSITY))
 valgrind_quiet_0 = --quiet
+valgrind_v_use   = $(valgrind_v_use_$(V))
+valgrind_v_use_  = $(valgrind_v_use_$(AM_DEFAULT_VERBOSITY))
+valgrind_v_use_0 = @echo "  USE   " $(patsubst check-valgrind-%,%,$''@):;
 
 # Support running with and without libtool.
 ifneq ($(LIBTOOL),)
@@ -144,7 +147,7 @@ endif
 # Use recursive makes in order to ignore errors during check
 check-valgrind:
 ifeq ($(VALGRIND_ENABLED),yes)
-	-$(foreach tool,$(valgrind_tools), \
+	-$(A''M_V_at)$(foreach tool,$(valgrind_tools), \
 		$(if $(VALGRIND_HAVE_TOOL_$(tool))$(VALGRIND_HAVE_TOOL_exp_$(tool)), \
 			$(MAKE) $(AM_MAKEFLAGS) -k check-valgrind-$(tool); \
 		) \
@@ -164,21 +167,18 @@ VALGRIND_LOG_COMPILER = \
 	$(valgrind_lt) \
 	$(VALGRIND) $(VALGRIND_SUPPRESSIONS) --error-exitcode=1 $(VALGRIND_FLAGS)
 
-ifeq ($(VALGRIND_ENABLED),yes)
 define valgrind_tool_rule =
 check-valgrind-$(1):
-	$$(MAKE) check-TESTS \
+ifeq ($(VALGRIND_ENABLED),yes)
+	$$(valgrind_v_use)$$(MAKE) check-TESTS \
 		TESTS_ENVIRONMENT="$$(VALGRIND_TESTS_ENVIRONMENT)" \
 		LOG_COMPILER="$$(VALGRIND_LOG_COMPILER)" \
 		LOG_FLAGS="$$(valgrind_$(1)_flags)" \
 		TEST_SUITE_LOG=test-suite-$(1).log
-endef
 else
-define valgrind_tool_rule =
-check-valgrind-$(1):
 	@echo "Need to reconfigure with --enable-valgrind"
-endef
 endif
+endef
 
 $(foreach tool,$(valgrind_tools),$(eval $(call valgrind_tool_rule,$(tool))))
 


### PR DESCRIPTION
This is a collection of four patches three of which are connected to running only some of the supported valgrind tools:
* refactor new tool-rules: remove code duplication
* add disabling individual tools: add configure command-line options
* make disabling configurable: add AX_VALGRIND_DFLT() function

Also add support for silent rules.