### PR TITLE
AX_PROG_DOXYGEN: cleanup doxygen_sqlite3.db

### DIFF
--- a/m4/ax_prog_doxygen.m4
+++ b/m4/ax_prog_doxygen.m4
@@ -97,7 +97,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 19
+#serial 20
 
 ## ----------##
 ## Defaults. ##
@@ -553,7 +553,8 @@ doxygen-doc: doxygen-run \$(DX_PS_GOAL) \$(DX_PDF_GOAL)
 ]])dnl
 [DX_CLEANFILES = \\]
 m4_foreach([DX_i], [DX_loop],
-[[	\$(DX_DOCDIR]DX_i[)/\$(PACKAGE).tag \\
+[[	\$(DX_DOCDIR]DX_i[)/doxygen_sqlite3.db \\
+	\$(DX_DOCDIR]DX_i[)/\$(PACKAGE).tag \\
 ]])dnl
 [	-r \\
 	\$(DX_CLEAN_HTML) \\


### PR DESCRIPTION
Add the file doxygen_sqlite3.db to DX_CLEANFILES. This file is
generated by (some?) newer versions of doxygen.