### PR TITLE
AX_COUNT_CPUS overhaul 

### DIFF
--- a/m4/ax_count_cpus.m4
+++ b/m4/ax_count_cpus.m4
@@ -4,18 +4,19 @@
 #
 # SYNOPSIS
 #
-#   AX_COUNT_CPUS
+#   AX_COUNT_CPUS([ACTION-IF-DETECTED],[ACTION-IF-NOT-DETECTED])
 #
 # DESCRIPTION
 #
-#   Attempt to count the number of processors present on the machine. If the
-#   detection fails, then a value of 1 is assumed.
-#
-#   The value is placed in the CPU_COUNT variable.
+#   Attempt to count the number of processors present on the machine and
+#   place detected value in CPU_COUNT variable. On successful detection,
+#   ACTION-IF-DETECTED is executed if present. If the detection fails, then
+#   ACTION-IF-NOT-DETECTED is triggered. The default ACTION-IF-NOT-DETECTED
+#   is to set CPU_COUNT to 1.
 #
 # LICENSE
 #
-#   Copyright (c) 2014 Karlson2k (Evgeny Grin) <k2k@narod.ru>
+#   Copyright (c) 2014,2016 Karlson2k (Evgeny Grin) <k2k@narod.ru>
 #   Copyright (c) 2012 Brian Aker <brian@tangent.org>
 #   Copyright (c) 2008 Michael Paul Bailey <jinxidoru@byu.net>
 #   Copyright (c) 2008 Christophe Tournayre <turn3r@users.sourceforge.net>
@@ -25,7 +26,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 11
+#serial 12
 
   AC_DEFUN([AX_COUNT_CPUS],[
       AC_REQUIRE([AC_CANONICAL_HOST])
@@ -57,10 +58,16 @@
           ])
         ])
 
-      AS_IF([test "x$CPU_COUNT" = "x0"],[
-        CPU_COUNT="1"
-        AC_MSG_RESULT( [unable to detect (assuming 1)] )
-        ],[
-        AC_MSG_RESULT( $CPU_COUNT )
-        ])
-      ])
+      AS_IF([test "x$CPU_COUNT" = "x0"],[dnl
+        m4_ifvaln([$2],[dnl
+            AC_MSG_RESULT([[unable to detect]])
+            $2
+          ], [dnl
+            CPU_COUNT="1"
+            AC_MSG_RESULT([[unable to detect (assuming 1)]])
+          ])dnl
+        ],[dnl
+          AC_MSG_RESULT([[$CPU_COUNT]])
+          m4_ifvaln([$1],[$1],)dnl
+        ])dnl
+      ])dnl

--- a/m4/ax_count_cpus.m4
+++ b/m4/ax_count_cpus.m4
@@ -58,16 +58,17 @@
           ])
         ])
 
-      AS_IF([test "x$CPU_COUNT" = "x0"],[dnl
-        m4_ifvaln([$2],[dnl
+      AS_IF([[test "x$CPU_COUNT" != "x0" && test "$CPU_COUNT" -gt 0 2>/dev/null]],[dnl
+          AC_MSG_RESULT([[$CPU_COUNT]])
+          m4_ifvaln([$1],[$1],)dnl
+        ],[dnl
+          m4_ifval([$2],[dnl
+            AS_UNSET([[CPU_COUNT]])
             AC_MSG_RESULT([[unable to detect]])
             $2
           ], [dnl
             CPU_COUNT="1"
             AC_MSG_RESULT([[unable to detect (assuming 1)]])
           ])dnl
-        ],[dnl
-          AC_MSG_RESULT([[$CPU_COUNT]])
-          m4_ifvaln([$1],[$1],)dnl
         ])dnl
       ])dnl

--- a/m4/ax_count_cpus.m4
+++ b/m4/ax_count_cpus.m4
@@ -8,11 +8,13 @@
 #
 # DESCRIPTION
 #
-#   Attempt to count the number of processors present on the machine and
-#   place detected value in CPU_COUNT variable. On successful detection,
-#   ACTION-IF-DETECTED is executed if present. If the detection fails, then
-#   ACTION-IF-NOT-DETECTED is triggered. The default ACTION-IF-NOT-DETECTED
-#   is to set CPU_COUNT to 1.
+#   Attempt to count the number of logical processor cores (including
+#   virtual and HT cores) currently available to use on the machine and
+#   place detected value in CPU_COUNT variable.
+#
+#   On successful detection, ACTION-IF-DETECTED is executed if present. If
+#   the detection fails, then ACTION-IF-NOT-DETECTED is triggered. The
+#   default ACTION-IF-NOT-DETECTED is to set CPU_COUNT to 1.
 #
 # LICENSE
 #
@@ -26,7 +28,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 13
+#serial 17
 
   AC_DEFUN([AX_COUNT_CPUS],[dnl
       AC_REQUIRE([AC_CANONICAL_HOST])dnl

--- a/m4/ax_count_cpus.m4
+++ b/m4/ax_count_cpus.m4
@@ -49,8 +49,9 @@
             ])
           ])],[
         *mingw*],[
-        AS_IF([test -n "$NUMBER_OF_PROCESSORS"],[
-          CPU_COUNT="$NUMBER_OF_PROCESSORS"
+        CPU_COUNT=`reg query HKLM\\\\Hardware\\\\Description\\\\System\\\\CentralProcessor 2>/dev/null | $EGREP -c '@<:@0-9@:>@+' -c` || CPU_COUNT="0"
+        AS_IF([[test "$CPU_COUNT" -eq "0" && test "$NUMBER_OF_PROCESSORS" -gt "0" 2>/dev/null]],[dnl
+          CPU_COUNT="$NUMBER_OF_PROCESSORS" # Fallback to simple method
           ])],[
         *cygwin*],[
         AS_IF([test -n "$NUMBER_OF_PROCESSORS"],[


### PR DESCRIPTION
Almost complete overwrite of AX_COUNT_CPUS.
Now detection is not limited to known platforms and should work on most current platforms.
Used locale-independent and machine-parseable commands if possible so results must be predictable and stable.
Macro now tries to detect currently enabled CPUs (it's possible in some OSes to disable specific CPU core).
Several methods are used for any platforms (at least three), for popular platforms can be used up to six detection methods so chances of success are really high. :smiley: 
Tested on Linuxes, FreeBSD, MSys2, MSys, Cygwin, MinGW, Solaris and Darwin.
Should correctly detect number of CPUs on current and previous OS versions and may detect on exotic platforms.
Added support for ACTION-IF-DETECTED and ACTION-IF-NOT-DETECTED so it's possible to distinguish between one CPU core and failed detection. 

Some commits could be squashed, if required.