### PR TITLE
fix include errors w/AX_CXX_COMPILE_STDCXX_1[14]

### DIFF
--- a/m4/ax_cxx_compile_stdcxx_11.m4
+++ b/m4/ax_cxx_compile_stdcxx_11.m4
@@ -33,8 +33,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 16
+#serial 17
 
-include([ax_cxx_compile_stdcxx.m4])
-
+AX_REQUIRE_DEFINED([AX_CXX_COMPILE_STDCXX])
 AC_DEFUN([AX_CXX_COMPILE_STDCXX_11], [AX_CXX_COMPILE_STDCXX([11], [$1], [$2])])

--- a/m4/ax_cxx_compile_stdcxx_14.m4
+++ b/m4/ax_cxx_compile_stdcxx_14.m4
@@ -28,8 +28,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 3
+#serial 4
 
-include([ax_cxx_compile_stdcxx.m4])
-
+AX_REQUIRE_DEFINED([AX_CXX_COMPILE_STDCXX])
 AC_DEFUN([AX_CXX_COMPILE_STDCXX_14], [AX_CXX_COMPILE_STDCXX([14], [$1], [$2])])


### PR DESCRIPTION
The search path for `include` is the current working directory, so trying
to include other m4 files directly only works if they live in the same dir
as where you're running `aclocal`.  Otherwise we end up with errors like:
	$ cd lcd4linux-0.10.1-RC2
	$ aclocal
	/usr/share/aclocal/ax_cxx_compile_stdcxx_14.m4:32: file 'ax_cxx_compile_stdcxx.m4' does not exist

Use the AX_REQUIRE_DEFINED macro instead to make sure the macro we want
exists.