### PR TITLE
Update ax_with_curses.m4 and ax_with_curses_extra.m4 to match PKG_CHECK_MODULES style

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,26 @@
 
 * Noteworthy changes in release ?.? (????-??-??) [?]
 
+  AX_WITH_CURSES and AX_WITH_CURSES_* macros have been modernized, in line
+  with PKG_CHECK_MODULES's style. This change breaks the interface, but
+  makes AX_WITH_CURSES compatible and even completely replaceable with the
+  interface of PKG_CHECK_MODULES. Ultimately, these macros should be
+  replaced in the future by calls to PKG_CHECK_MODULES. Variables in
+  AX_WITH_CURSES have been renamed
+
+    CURSES_LIB -> CURSES_LIBS
+    CURSES_CPPFLAGS -> CURSES_CFLAGS
+
+  and for the AX_WITH_CURSES_* macros
+
+    PANEL_LIB -> PANEL_LIBS
+    MENU_LIB -> MENU_LIBS
+    FORM_LIB -> FORM_LIBS
+
+  such that once the variables have been renamed in configure.ac and Makefile.am,
+  the calls AX_WITH_CURSES and PKG_CHECK_MODULES([CURSES], [ncurses]) are
+  completely interchangeable.
+
 * Noteworthy changes in release 2016.03.20 (2016-03-20) [stable]
 
   The following new macros have been added: AX_CHECK_GIRS_GJS,

--- a/m4/ax_with_curses.m4
+++ b/m4/ax_with_curses.m4
@@ -57,19 +57,23 @@
 #   The following output variables are defined by this macro; they are
 #   precious and may be overridden on the ./configure command line:
 #
-#     CURSES_LIB  - library to add to xxx_LDADD
-#     CURSES_CPPFLAGS  - include paths to add to xxx_CPPFLAGS
+#     CURSES_LIBS  - library to add to xxx_LDADD
+#     CURSES_CFLAGS  - include paths to add to xxx_CPPFLAGS
 #
-#   Neither the library listed in CURSES_LIB, nor the flags in
-#   CURSES_CPPFLAGS are added to LIBS, respectively CPPFLAGS, by default.
-#   You need to add both to the appropriate xxx_LDADD/xxx_CPPFLAGS line in
-#   your Makefile.am. For example:
+#   In previous versions of this macro, the flags CURSES_LIB and
+#   CURSES_CPPFLAGS were defined. These have been renamed, in keeping with
+#   AX_WITH_CURSES's close bigger brother, PKG_CHECK_MODULES, which should
+#   eventually supersede the use of AX_WITH_CURSES. Neither the library
+#   listed in CURSES_LIBS, nor the flags in CURSES_CFLAGS are added to LIBS,
+#   respectively CPPFLAGS, by default. You need to add both to the
+#   appropriate xxx_LDADD/xxx_CPPFLAGS line in your Makefile.am. For
+#   example:
 #
-#     prog_LDADD = @CURSES_LIB@
-#     prog_CPPFLAGS = @CURSES_CPPFLAGS@
+#     prog_LDADD = @CURSES_LIBS@
+#     prog_CPPFLAGS = @CURSES_CFLAGS@
 #
-#   If CURSES_LIB is set on the configure command line (such as by running
-#   "./configure CURSES_LIB=-lmycurses"), then the only header searched for
+#   If CURSES_LIBS is set on the configure command line (such as by running
+#   "./configure CURSES_LIBS=-lmycurses"), then the only header searched for
 #   is <curses.h>. If the user needs to specify an alternative path for a
 #   library (such as for a non-standard NcurseW), the user should use the
 #   LDFLAGS variable.
@@ -186,14 +190,15 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 16
+#serial 17
 
 # internal function to factorize common code that is used by both ncurses
 # and ncursesw
 AC_DEFUN([_FIND_CURSES_FLAGS], [
     AC_MSG_CHECKING([for $1 via pkg-config])
 
-    _PKG_CONFIG([_ax_cv_$1_lib], [libs], [$1])
+    AX_REQUIRE_DEFINED([PKG_CHECK_EXISTS])
+    _PKG_CONFIG([_ax_cv_$1_libs], [libs], [$1])
     _PKG_CONFIG([_ax_cv_$1_cppflags], [cflags], [$1])
 
     AS_IF([test "x$pkg_failed" = "xyes" || test "x$pkg_failed" = "xuntried"],[
@@ -201,27 +206,27 @@ AC_DEFUN([_FIND_CURSES_FLAGS], [
         # No suitable .pc file found, have to find flags via fallback
         AC_CACHE_CHECK([for $1 via fallback], [ax_cv_$1], [
             AS_ECHO()
-            pkg_cv__ax_cv_$1_lib="-l$1"
-            pkg_cv__ax_cv_$1_cppflags="$CURSES_CPPFLAGS"
-            LIBS="$ax_saved_LIBS $pkg_cv__ax_cv_$1_lib"
+            pkg_cv__ax_cv_$1_libs="-l$1"
+            pkg_cv__ax_cv_$1_cppflags="-D_GNU_SOURCE $CURSES_CFLAGS"
+            LIBS="$ax_saved_LIBS $pkg_cv__ax_cv_$1_libs"
             CPPFLAGS="$ax_saved_CPPFLAGS $pkg_cv__ax_cv_$1_cppflags"
 
-            AC_MSG_CHECKING([for initscr() with $pkg_cv__ax_cv_$1_lib])
+            AC_MSG_CHECKING([for initscr() with $pkg_cv__ax_cv_$1_libs])
             AC_LINK_IFELSE([AC_LANG_CALL([], [initscr])],
                 [
                     AC_MSG_RESULT([yes])
-                    AC_MSG_CHECKING([for nodelay() with $pkg_cv__ax_cv_$1_lib])
+                    AC_MSG_CHECKING([for nodelay() with $pkg_cv__ax_cv_$1_libs])
                     AC_LINK_IFELSE([AC_LANG_CALL([], [nodelay])],[
                         ax_cv_$1=yes
                         ],[
                         AC_MSG_RESULT([no])
                         m4_if(
-                            [$1],[ncursesw],[pkg_cv__ax_cv_$1_lib="$pkg_cv__ax_cv_$1_lib -ltinfow"],
-                            [$1],[ncurses],[pkg_cv__ax_cv_$1_lib="$pkg_cv__ax_cv_$1_lib -ltinfo"]
+                            [$1],[ncursesw],[pkg_cv__ax_cv_$1_libs="$pkg_cv__ax_cv_$1_libs -ltinfow"],
+                            [$1],[ncurses],[pkg_cv__ax_cv_$1_libs="$pkg_cv__ax_cv_$1_libs -ltinfo"]
                         )
-                        LIBS="$ax_saved_LIBS $pkg_cv__ax_cv_$1_lib"
+                        LIBS="$ax_saved_LIBS $pkg_cv__ax_cv_$1_libs"
 
-                        AC_MSG_CHECKING([for nodelay() with $pkg_cv__ax_cv_$1_lib])
+                        AC_MSG_CHECKING([for nodelay() with $pkg_cv__ax_cv_$1_libs])
                         AC_LINK_IFELSE([AC_LANG_CALL([], [nodelay])],[
                             ax_cv_$1=yes
                             ],[
@@ -235,7 +240,7 @@ AC_DEFUN([_FIND_CURSES_FLAGS], [
         ],[
         AC_MSG_RESULT([yes])
         # Found .pc file, using its information
-        LIBS="$ax_saved_LIBS $pkg_cv__ax_cv_$1_lib"
+        LIBS="$ax_saved_LIBS $pkg_cv__ax_cv_$1_libs"
         CPPFLAGS="$ax_saved_CPPFLAGS $pkg_cv__ax_cv_$1_cppflags"
         ax_cv_$1=yes
     ])
@@ -243,15 +248,14 @@ AC_DEFUN([_FIND_CURSES_FLAGS], [
 
 AU_ALIAS([MP_WITH_CURSES], [AX_WITH_CURSES])
 AC_DEFUN([AX_WITH_CURSES], [
-    AC_ARG_VAR([CURSES_LIB], [linker library for Curses, e.g. -lcurses])
-    AC_ARG_VAR([CURSES_CPPFLAGS], [preprocessor flags for Curses, e.g. -I/usr/include/ncursesw])
+    AC_ARG_VAR([CURSES_LIBS], [linker library for Curses, e.g. -lcurses])
+    AC_ARG_VAR([CURSES_CFLAGS], [preprocessor flags for Curses, e.g. -I/usr/include/ncursesw])
     AC_ARG_WITH([ncurses], [AS_HELP_STRING([--with-ncurses],
         [force the use of Ncurses or NcursesW])],
         [], [with_ncurses=check])
     AC_ARG_WITH([ncursesw], [AS_HELP_STRING([--without-ncursesw],
         [do not use NcursesW (wide character support)])],
         [], [with_ncursesw=check])
-    AC_REQUIRE([PKG_PROG_PKG_CONFIG])
 
     ax_saved_LIBS=$LIBS
     ax_saved_CPPFLAGS=$CPPFLAGS
@@ -262,7 +266,7 @@ AC_DEFUN([AX_WITH_CURSES], [
     ax_cv_curses_which=no
 
     # Test for NcursesW
-    AS_IF([test "x$CURSES_LIB" = x && test "x$with_ncursesw" != xno], [
+    AS_IF([test "x$CURSES_LIBS" = x && test "x$with_ncursesw" != xno], [
         _FIND_CURSES_FLAGS([ncursesw])
 
         AS_IF([test "x$ax_cv_ncursesw" = xno && test "x$with_ncursesw" = xyes], [
@@ -272,8 +276,8 @@ AC_DEFUN([AX_WITH_CURSES], [
         AS_IF([test "x$ax_cv_ncursesw" = xyes], [
             ax_cv_curses=yes
             ax_cv_curses_which=ncursesw
-            CURSES_LIB="$pkg_cv__ax_cv_ncursesw_lib"
-            CURSES_CPPFLAGS="$pkg_cv__ax_cv_ncursesw_cppflags"
+            CURSES_LIBS="$pkg_cv__ax_cv_ncursesw_libs"
+            CURSES_CFLAGS="$pkg_cv__ax_cv_ncursesw_cppflags"
             AC_DEFINE([HAVE_NCURSESW], [1], [Define to 1 if the NcursesW library is present])
             AC_DEFINE([HAVE_CURSES],   [1], [Define to 1 if a SysV or X/Open compatible Curses library is present])
 
@@ -375,11 +379,11 @@ AC_DEFUN([AX_WITH_CURSES], [
             ])
         ])
     ])
-    unset pkg_cv__ax_cv_ncursesw_lib
+    unset pkg_cv__ax_cv_ncursesw_libs
     unset pkg_cv__ax_cv_ncursesw_cppflags
 
     # Test for Ncurses
-    AS_IF([test "x$CURSES_LIB" = x && test "x$with_ncurses" != xno && test "x$ax_cv_curses_which" = xno], [
+    AS_IF([test "x$CURSES_LIBS" = x && test "x$with_ncurses" != xno && test "x$ax_cv_curses_which" = xno], [
         _FIND_CURSES_FLAGS([ncurses])
 
         AS_IF([test "x$ax_cv_ncurses" = xno && test "x$with_ncurses" = xyes], [
@@ -389,8 +393,8 @@ AC_DEFUN([AX_WITH_CURSES], [
         AS_IF([test "x$ax_cv_ncurses" = xyes], [
             ax_cv_curses=yes
             ax_cv_curses_which=ncurses
-            CURSES_LIB="$pkg_cv__ax_cv_ncurses_lib"
-            CURSES_CPPFLAGS="$pkg_cv__ax_cv_ncurses_cppflags"
+            CURSES_LIBS="$pkg_cv__ax_cv_ncurses_libs"
+            CURSES_CFLAGS="$pkg_cv__ax_cv_ncurses_cppflags"
             AC_DEFINE([HAVE_NCURSES], [1], [Define to 1 if the Ncurses library is present])
             AC_DEFINE([HAVE_CURSES],  [1], [Define to 1 if a SysV or X/Open compatible Curses library is present])
 
@@ -445,13 +449,13 @@ AC_DEFUN([AX_WITH_CURSES], [
             ])
         ])
     ])
-    unset pkg_cv__ax_cv_ncurses_lib
+    unset pkg_cv__ax_cv_ncurses_libs
     unset pkg_cv__ax_cv_ncurses_cppflags
 
-    # Test for plain Curses (or if CURSES_LIB was set by user)
+    # Test for plain Curses (or if CURSES_LIBS was set by user)
     AS_IF([test "x$with_plaincurses" != xno && test "x$ax_cv_curses_which" = xno], [
-        AS_IF([test "x$CURSES_LIB" != x], [
-            LIBS="$ax_saved_LIBS $CURSES_LIB"
+        AS_IF([test "x$CURSES_LIBS" != x], [
+            LIBS="$ax_saved_LIBS $CURSES_LIBS"
         ], [
             LIBS="$ax_saved_LIBS -lcurses"
         ])
@@ -464,8 +468,8 @@ AC_DEFUN([AX_WITH_CURSES], [
         AS_IF([test "x$ax_cv_plaincurses" = xyes], [
             ax_cv_curses=yes
             ax_cv_curses_which=plaincurses
-            AS_IF([test "x$CURSES_LIB" = x], [
-                CURSES_LIB="-lcurses"
+            AS_IF([test "x$CURSES_LIBS" = x], [
+                CURSES_LIBS="-lcurses"
             ])
             AC_DEFINE([HAVE_CURSES], [1], [Define to 1 if a SysV or X/Open compatible Curses library is present])
 

--- a/m4/ax_with_curses_extra.m4
+++ b/m4/ax_with_curses_extra.m4
@@ -41,18 +41,22 @@
 #   The following output variables may be defined by these macros; these are
 #   precious and may be overridden on the ./configure command line:
 #
-#     PANEL_LIB   - library to add to xxx_LDADD before CURSES_LIB
-#     MENU_LIB    - library to add to xxx_LDADD before CURSES_LIB
-#     FORM_LIB    - library to add to xxx_LDADD before CURSES_LIB
+#     PANEL_LIBS   - library to add to xxx_LDADD before CURSES_LIBS
+#     MENU_LIBS    - library to add to xxx_LDADD before CURSES_LIBS
+#     FORM_LIBS    - library to add to xxx_LDADD before CURSES_LIBS
 #
-#   These libraries are NOT added to LIBS by default.  You need to add them
-#   to the appropriate xxx_LDADD line in your Makefile.am in front of the
-#   equivalent CURSES_LIB incantation.  For example:
+#   In previous versions of this macro, the flags PANEL_LIB, MENU_LIB and
+#   FORM_LIB were defined. These have been renamed, in keeping with the
+#   variable scheme of PKG_CHECK_MODULES, which should eventually supersede
+#   the use of AX_WITH_CURSES and AX_WITH_CURSES_* macros. These libraries
+#   are NOT added to LIBS by default.  You need to add them to the
+#   appropriate xxx_LDADD line in your Makefile.am in front of the
+#   equivalent CURSES_LIBS incantation.  For example:
 #
-#     prog_LDADD = @PANEL_LIB@ @CURSES_LIB@
+#     prog_LDADD = @PANEL_LIBS@ @CURSES_LIBS@
 #
-#   If one of the xxx_LIB variables is set on the configure command line
-#   (such as by running "./configure PANEL_LIB=-lmypanel"), then the header
+#   If one of the xxx_LIBS variables is set on the configure command line
+#   (such as by running "./configure PANEL_LIBS=-lmypanel"), then the header
 #   file searched must NOT contain a subpath.  In this case, in other words,
 #   only <panel.h> would be searched for.  The user may use the CPPFLAGS
 #   precious variable to override the standard #include search path.
@@ -144,7 +148,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 3
+#serial 4
 
 AC_DEFUN([_AX_WITH_CURSES_CHECKEXTRA], [
     dnl Parameter 1 is the variable name component, using uppercase letters only
@@ -159,8 +163,11 @@ AC_DEFUN([_AX_WITH_CURSES_CHECKEXTRA], [
     AS_VAR_PUSHDEF([_AX_WITH_CURSES_CHECKEXTRA_have_header_var], [HAVE_[]m4_toupper($4)])dnl
 
     ax_saved_LIBS=$LIBS
+    ax_saved_CPPFLAGS=$CPPFLAGS
+
     AC_CACHE_CHECK([for Curses $2 library with $4], [_AX_WITH_CURSES_CHECKEXTRA_header_var], [
-        LIBS="$ax_saved_LIBS $5 $CURSES_LIB"
+        LIBS="$ax_saved_LIBS $5 $CURSES_LIBS"
+        CPPFLAGS="$ax_saved_CPPFLAGS $CURSES_CFLAGS"
         AC_LINK_IFELSE([AC_LANG_PROGRAM([[
                 @%:@include <$4>
             ]], [$3])],
@@ -169,14 +176,18 @@ AC_DEFUN([_AX_WITH_CURSES_CHECKEXTRA], [
     ])
     AS_IF([test "x$[]_AX_WITH_CURSES_CHECKEXTRA_header_var" = xyes], [
         _AX_WITH_CURSES_CHECKEXTRA_cv_var=yes
-        AS_LITERAL_IF([$5], [$1_LIB="$5"])
+        AS_LITERAL_IF([$5], [$1_LIBS="$5"])
         AC_DEFINE([_AX_WITH_CURSES_CHECKEXTRA_have_var],        [1], [Define to 1 if the Curses $2 library is present])
         AC_DEFINE([_AX_WITH_CURSES_CHECKEXTRA_have_header_var], [1], [Define to 1 if <$4> is present])
     ], [
         AS_IF([test "x$[]_AX_WITH_CURSES_CHECKEXTRA_cv_var" = xyes], [],
             [_AX_WITH_CURSES_CHECKEXTRA_cv_var=no])
     ])
+
     LIBS=$ax_saved_LIBS
+    CPPFLAGS=$ax_saved_CPPFLAGS
+    unset ax_saved_LIBS
+    unset ax_saved_CPPFLAGS
 
     AS_VAR_POPDEF([_AX_WITH_CURSES_CHECKEXTRA_have_header_var])dnl
     AS_VAR_POPDEF([_AX_WITH_CURSES_CHECKEXTRA_header_var])dnl
@@ -194,16 +205,18 @@ AC_DEFUN([_AX_WITH_CURSES_EXTRA], [
     dnl Parameter 7 is the plain Curses library command line
 
     AC_REQUIRE([AX_WITH_CURSES])
-    AC_ARG_VAR([$1_LIB], [linker library for Curses $2, e.g. $7])
+    AC_ARG_VAR([$1_LIBS], [linker library for Curses $2, e.g. $7])
 
-    AS_IF([test "x$[]$1_LIB" != x], [
-        _AX_WITH_CURSES_CHECKEXTRA([$1], [$2], [$3], [$4], [$[]$1_LIB])
+    AS_IF([test "x$[]$1_LIBS" != x], [
+        _AX_WITH_CURSES_CHECKEXTRA([$1], [$2], [$3], [$4], [$[]$1_LIBS])
     ], [
         AS_IF([test "x$ax_cv_curses_which" = xncursesw], [
             _AX_WITH_CURSES_CHECKEXTRA([$1], [$2], [$3], [ncursesw/$4], [$5])
         ], [test "x$ax_cv_curses_which" = xncurses], [
-            _AX_WITH_CURSES_CHECKEXTRA([$1], [$2], [$3], [ncurses/$4], [$6])
             _AX_WITH_CURSES_CHECKEXTRA([$1], [$2], [$3], [$4], [$6])
+            AS_IF([test x$[]ax_cv_[]m4_tolower($1) != "xyes"], [
+                _AX_WITH_CURSES_CHECKEXTRA([$1], [$2], [$3], [ncurses/$4], [$6])
+            ])
         ], [test "x$ax_cv_curses_which" = xplaincurses], [
             _AX_WITH_CURSES_CHECKEXTRA([$1], [$2], [$3], [$4], [$7])
         ])


### PR DESCRIPTION
* Ultimately, ax_with_curses.m4 and ax_with_curses_extra.m4 should fall out of
  use once ncurses pkg-config files have become ubiquitous in the ecosystem.
  Until then, the precious variables have been renamed to match the style of
  `PKG_CHECK_MODULES`, such that a later replacement of the macros can be
  performed with a simple sed.