### PR TITLE
AX_CHECK_OPENSSL: use AC_CHECK_TOOL for pkg-config

### DIFF
--- a/m4/ax_check_openssl.m4
+++ b/m4/ax_check_openssl.m4
@@ -32,7 +32,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 8
+#serial 9
 
 AU_ALIAS([CHECK_SSL], [AX_CHECK_OPENSSL])
 AC_DEFUN([AX_CHECK_OPENSSL], [
@@ -51,7 +51,7 @@ AC_DEFUN([AX_CHECK_OPENSSL], [
         ], [
             # if pkg-config is installed and openssl has installed a .pc file,
             # then use that information and don't search ssldirs
-            AC_PATH_PROG([PKG_CONFIG], [pkg-config])
+            AC_CHECK_TOOL([PKG_CONFIG], [pkg-config])
             if test x"$PKG_CONFIG" != x""; then
                 OPENSSL_LDFLAGS=`$PKG_CONFIG openssl --libs-only-L 2>/dev/null`
                 if test $? = 0; then


### PR DESCRIPTION
Some distros provide prefixed pkg-config. This patch ensures
the right tool is picked.

See https://www.gnu.org/software/autoconf/manual/autoconf.html#Generic-Programs
for details