### PR TITLE
Fix for ax_cflags_warn_all to properly detect Compaq C flags

### DIFF
--- a/m4/ax_cflags_warn_all.m4
+++ b/m4/ax_cflags_warn_all.m4
@@ -78,8 +78,8 @@ in "-warn all  % -warn all"   dnl Intel
    "-h conform % -h msglevel 2" dnl Cray C (Unicos)
    #
 do FLAGS="$ac_save_[]FLAGS "`echo $ac_arg | sed -e 's,%%.*,,' -e 's,%,,'`
-   AC_COMPILE_IFELSE([AC_LANG_PROGRAM],
-                     [VAR=`echo $ac_arg | sed -e 's,.*% *,,'` ; break])
+   AC_LINK_IFELSE([AC_LANG_PROGRAM],
+                  [VAR=`echo $ac_arg | sed -e 's,.*% *,,'` ; break])
 done
 FLAGS="$ac_save_[]FLAGS"
 ])


### PR DESCRIPTION
I've run across a bug in the script ax_cflags_warn_all.m4 when testing on Tru64 (OSF/1) 5.1B when using the Compaq C (previously Digital C) compiler. The script is meant to determine which flags to use to enable all warnings.  On the platform described, it always selects the Intel flags for a very odd
reason.

Compaq C, when it encounters an unknown flag starting with either "W" or "w," passes the flag to the linker when linking is requested.  If the user is just compiling, no action is taken.  Therefore, the C compiler will accept the flags "-warn all" which is Intel-specific.  However, if linking were requested, an error is raised correctly.

In order to properly test the Compaq C compiler's accepted flag, linking has to be tested as well.

I realize Compaq C is a niche and obsolete system at this point, but the fix is neccesary to support the compiler.
