### PR TITLE
remove useless ppc64le trailing word in libsubdirs

### DIFF
--- a/m4/ax_boost_base.m4
+++ b/m4/ax_boost_base.m4
@@ -33,7 +33,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 26
+#serial 27
 
 AC_DEFUN([AX_BOOST_BASE],
 [
@@ -96,7 +96,7 @@ if test "x$want_boost" = "xyes"; then
         libsubdirs="lib64 libx32 lib lib64"
         ;;
       ppc64|s390x|sparc64|aarch64|ppc64le)
-        libsubdirs="lib64 lib lib64 ppc64le"
+        libsubdirs="lib64 lib lib64"
         ;;
     esac
 


### PR DESCRIPTION
this is a typo correction of previous commit 1f9acf39e6b3
as per original patch from https://savannah.gnu.org/patch/index.php?8473