### PR TITLE
ax_prog_gjs: Look in pkg-config as well as path

### DIFF
--- a/m4/ax_prog_gjs.m4
+++ b/m4/ax_prog_gjs.m4
@@ -9,10 +9,10 @@
 # DESCRIPTION
 #
 #   AX_PROG_GJS checks for the presence of the JavaScript interpreter GJS
-#   (https://wiki.gnome.org/Projects/Gjs) in the path. If it is not found,
-#   an error is issued and configure is halted. If it is found, the path of
-#   the interpreter is placed into a variable named GJS, which is declared
-#   precious.
+#   (https://wiki.gnome.org/Projects/Gjs) in pkg-config or in the path. If
+#   it is not found, an error is issued and configure is halted. If it is
+#   found, the path of the interpreter is placed into a variable named GJS,
+#   which is declared precious.
 #
 # LICENSE
 #
@@ -23,11 +23,19 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 1
+#serial 2
 
 AC_DEFUN_ONCE([AX_PROG_GJS], [
+  AC_REQUIRE([PKG_PROG_PKG_CONFIG])
   AC_ARG_VAR([GJS], [Path to GJS interpreter])
-  AC_PATH_PROG([GJS], [gjs], [notfound])
+  AC_MSG_CHECKING([for GJS])
+  AS_IF([pkg-config --exists gjs-1.0], [
+    GJS=`pkg-config --variable=gjs_console gjs-1.0`
+    AC_MSG_RESULT([(pkg-config) $GJS])
+  ], [
+    AC_PATH_PROG([GJS], [gjs], [notfound])
+    AC_MSG_RESULT([(path) $GJS])
+  ])
   AS_IF([test "x$GJS" = "xnotfound"],
     [AC_MSG_ERROR([GJS is required, but was not found. If GJS is
 installed, try passing its path in an environment variable,


### PR DESCRIPTION
This looks in pkg-config for the GJS executable, since the gjs-1.0
package provides it as a pkg-config variable. However, not all versions
of GJS do, so we fall back to checking in the path.