### PR TITLE
Fix reference to LIBMYSQLCPPCONN_CXXFLAGS

### DIFF
--- a/m4/ax_lib_mysqlcppconn.m4
+++ b/m4/ax_lib_mysqlcppconn.m4
@@ -35,7 +35,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 1
+#serial 2
 
 AC_DEFUN([AX_LIB_MYSQLCPPCONN],
 [
@@ -125,8 +125,12 @@ if test "x$want_libmysqlcppconn" = "xyes"; then
     fi
 
     CXXFLAGS_SAVED="$CXXFLAGS"
-    CXXFLAGS="$CXXFLAGS $LIBMYSQLCPPCONN_CFLAGS"
+    CXXFLAGS="$CXXFLAGS $LIBMYSQLCPPCONN_CXXFLAGS"
     export CXXFLAGS
+
+    CPPFLAGS_SAVED="$CPPFLAGS"
+    CPPFLAGS="$CPPFLAGS $LIBMYSQLCPPCONN_CXXFLAGS"
+    export CPPFLAGS
 
     LDFLAGS_SAVED="$LDFLAGS"
     LDFLAGS="$LDFLAGS $LIBMYSQLCPPCONN_LDFLAGS"
@@ -165,6 +169,9 @@ if test "x$want_libmysqlcppconn" = "xyes"; then
 
     CXXFLAGS="$CXXFLAGS_SAVED"
     export CXXFLAGS
+
+    CPPFLAGS="$CPPFLAGS_SAVED"
+    export CPPFLAGS
 
     LDFLAGS="$LDFLAGS_SAVED"
     export LDFLAGS


### PR DESCRIPTION
ax_lib_mysqlcppconn.m4 has a typo referencing CFLAGS. This typo prevents --with-libmysqlcppconn from being used.