### PR TITLE
ax_compiler_flags_*: fix underquoting causing infinite recursion

### DIFF
--- a/m4/ax_compiler_flags_cflags.m4
+++ b/m4/ax_compiler_flags_cflags.m4
@@ -25,7 +25,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 11
+#serial 12
 
 AC_DEFUN([AX_COMPILER_FLAGS_CFLAGS],[
     AC_REQUIRE([AC_PROG_SED])
@@ -34,7 +34,7 @@ AC_DEFUN([AX_COMPILER_FLAGS_CFLAGS],[
     AX_REQUIRE_DEFINED([AX_CHECK_COMPILE_FLAG])
 
     # Variable names
-    m4_define(ax_warn_cflags_variable,
+    m4_define([ax_warn_cflags_variable],
               [m4_normalize(ifelse([$1],,[WARN_CFLAGS],[$1]))])
 
     AC_LANG_PUSH([C])

--- a/m4/ax_compiler_flags_cxxflags.m4
+++ b/m4/ax_compiler_flags_cxxflags.m4
@@ -26,7 +26,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AC_DEFUN([AX_COMPILER_FLAGS_CXXFLAGS],[
     AC_REQUIRE([AC_PROG_SED])
@@ -35,7 +35,7 @@ AC_DEFUN([AX_COMPILER_FLAGS_CXXFLAGS],[
     AX_REQUIRE_DEFINED([AX_CHECK_COMPILE_FLAG])
 
     # Variable names
-    m4_define(ax_warn_cxxflags_variable,
+    m4_define([ax_warn_cxxflags_variable],
               [m4_normalize(ifelse([$1],,[WARN_CXXFLAGS],[$1]))])
 
     AC_LANG_PUSH([C++])

--- a/m4/ax_compiler_flags_gir.m4
+++ b/m4/ax_compiler_flags_gir.m4
@@ -26,13 +26,13 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 4
+#serial 5
 
 AC_DEFUN([AX_COMPILER_FLAGS_GIR],[
     AX_REQUIRE_DEFINED([AX_APPEND_FLAG])
 
     # Variable names
-    m4_define(ax_warn_scannerflags_variable,
+    m4_define([ax_warn_scannerflags_variable],
               [m4_normalize(ifelse([$1],,[WARN_SCANNERFLAGS],[$1]))])
 
     # Base flags

--- a/m4/ax_compiler_flags_ldflags.m4
+++ b/m4/ax_compiler_flags_ldflags.m4
@@ -25,7 +25,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 5
+#serial 6
 
 AC_DEFUN([AX_COMPILER_FLAGS_LDFLAGS],[
     AX_REQUIRE_DEFINED([AX_APPEND_LINK_FLAGS])
@@ -33,7 +33,7 @@ AC_DEFUN([AX_COMPILER_FLAGS_LDFLAGS],[
     AX_REQUIRE_DEFINED([AX_CHECK_COMPILE_FLAG])
 
     # Variable names
-    m4_define(ax_warn_ldflags_variable,
+    m4_define([ax_warn_ldflags_variable],
               [m4_normalize(ifelse([$1],,[WARN_LDFLAGS],[$1]))])
 
     # Always pass -Werror=unknown-warning-option to get Clang to fail on bad


### PR DESCRIPTION
These macros would fail with infinite recursion if used twice for the
same variable, for example

    AX_COMPILER_FLAGS_CFLAGS([WARN_CFLAGS], ... some options ...)
    AX_COMPILER_FLAGS_CFLAGS([WARN_CFLAGS], ... more options ...)

In particular, invoking AX_COMPILER_FLAGS, followed by
AX_COMPILER_FLAGS_CFLAGS with more "yes" options has this failure mode.

This is because the first time through the macro, we define
ax_warn_cflags_variable = "WARN_CFLAGS" as expected. The second time,
because the first parameter is underquoted, its value is substituted
before calling m4_define, so we inadvertently define
WARN_CFLAGS = "WARN_CFLAGS". The next time WARN_CFLAGS is mentioned,
attempts to expand it will recurse forever, because m4 does not
special-case a macro that appears in its own expansion like cpp does.

Signed-off-by: Simon McVittie <smcv@debian.org>

---

cc @pwithnall 