### PR TITLE
Remove extraneous whitespace to make ifelse() work

### DIFF
--- a/m4/ax_define_sub_path.m4
+++ b/m4/ax_define_sub_path.m4
@@ -79,7 +79,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 8
+#serial 9
 
 AU_ALIAS([AC_DEFINE_SUB_PATH], [AX_DEFINE_SUB_PATH])
 AC_DEFUN([AX_DEFINE_SUB_PATH],
@@ -87,7 +87,7 @@ AC_DEFUN([AX_DEFINE_SUB_PATH],
   test "_$prefix" = _NONE && prefix="$ac_default_prefix"
   test "_$exec_prefix" = _NONE && exec_prefix='${prefix}'
   P=`echo ifelse( $2, , [$]$1, [$]$2) | sed -e 's:^\${[a-z_]*prefix}:.:'`
-  ifelse ($3, ,
+  ifelse($3, ,
     AC_DEFINE($1, $P, [sub path $2]),
     AC_DEFINE($1, $P, $3))
 ])


### PR DESCRIPTION
I noticed this when trying to figure out what this macro is useful for. I have to admit that I still don’t know…? Could you explain what the intended use-case is?

I was hoping it could be used for defining a C preprocessor macro (via `AC_DEFINE`) that contained an expanded ${sysconfdir}, but — even with the necessary bugfixes — the description says the macro will merely replace `${prefix}` with a dotslash.

In the end, I resorted to using:
```m4
AC_DEFINE_UNQUOTED(SYSCONFDIR, "`eval echo $sysconfdir`", [Location of system configuration files])
```

Also, should we consider deleting the macro entirely instead of merging this pull request? As per https://codesearch.debian.net/search?q=AX_DEFINE_SUB_PATH and https://codesearch.debian.net/search?q=AC_DEFINE_SUB_PATH and a quick Google search, there are no users of this macro (not surprising as it’s broken, but nobody cared enough to submit a fix until now).