### PR TITLE
ax_enable_builddir: require AC_CANONICAL_TARGET

### DIFF
--- a/m4/ax_enable_builddir.m4
+++ b/m4/ax_enable_builddir.m4
@@ -79,10 +79,11 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 24
+#serial 25
 
 AC_DEFUN([AX_ENABLE_BUILDDIR],[
 AC_REQUIRE([AC_CANONICAL_HOST])[]dnl
+AC_REQUIRE([AC_CANONICAL_TARGET])[]dnl
 AC_REQUIRE([AX_CONFIGURE_ARGS])[]dnl
 AC_REQUIRE([AM_AUX_DIR_EXPAND])[]dnl
 AC_BEFORE([$0],[AM_INIT_AUTOMAKE])dnl


### PR DESCRIPTION
Without AC_CANONICAL_TARGET, I get the following error when running
./configure:

    checking build system type... x86_64-unknown-linux-gnu
    checking host system type... x86_64-unknown-linux-gnu
    mkdir: cannot create directory '': No such file or directory
    mkdir: cannot create directory '': No such file or directory
    ./configure: line 2470: /conftest.tmp: Permission denied
    configure: error: could not change to default builddir "./"

With AC_CANONICAL_TARGET (either called explicitly in configure.ac, or
required in AX_ENABLE_BUILDDIR), ./configure works as expected:

    checking build system type... x86_64-unknown-linux-gnu
    checking host system type... x86_64-unknown-linux-gnu
    checking target system type... x86_64-unknown-linux-gnu
    continue configure in default builddir "./x86_64-unknown-linux-gnu"
    ....exec /nix/store/nyj6xd7s1n1w8c0xdwk5ddhi7bjcyi9x-bash-4.3-p46/bin/bash .././configure "--srcdir=.." "--enable-builddir=x86_64-unknown-linux-gnu" "linux
    gnu"
    checking build system type... x86_64-unknown-linux-gnu
    checking host system type... x86_64-unknown-linux-gnu
    checking target system type... x86_64-unknown-linux-gnu
    checking for gsed... sed
    […]