### PR TITLE
ax_extend_srcdir: also accept absolute paths

### DIFF
--- a/m4/ax_extend_srcdir.m4
+++ b/m4/ax_extend_srcdir.m4
@@ -69,12 +69,12 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 3
+#serial 4
 
 AC_DEFUN([AX_EXTEND_SRCDIR],
 [dnl
 AS_CASE([$srcdir],
-  [.|.*],
+  [.|.*|/*],
   [
     # pwd -P is specified in IEEE 1003.1 from 2004
     as_dir=`cd "$srcdir" && pwd -P`


### PR DESCRIPTION
This is important for the FreeBSD ports and was submitted by https://github.com/bapt in https://github.com/i3/i3/pull/2551