### PR TITLE
Find Java directories on recent macOS versions

### DIFF
--- a/m4/ax_jni_include_dir.m4
+++ b/m4/ax_jni_include_dir.m4
@@ -44,7 +44,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 11
+#serial 12
 
 AU_ALIAS([AC_JNI_INCLUDE_DIR], [AX_JNI_INCLUDE_DIR])
 AC_DEFUN([AX_JNI_INCLUDE_DIR],[
@@ -66,14 +66,17 @@ else
 fi
 
 case "$host_os" in
-        darwin*)        # Apple JDK is at /System location and has headers symlinked elsewhere
-                        case "$_JTOPDIR" in
-                        /System/Library/Frameworks/JavaVM.framework/*)
-				_JTOPDIR=`echo "$_JTOPDIR" | sed -e 's:/[[^/]]*$::'`
-				_JINC="$_JTOPDIR/Headers";;
-			*)      _JINC="$_JTOPDIR/include";;
-                        esac;;
-        *)              _JINC="$_JTOPDIR/include";;
+        darwin*)        # Apple Java headers are inside the Xcode bundle.
+            macos_version=$(sw_vers -productVersion | sed -n -e 's/^@<:@0-9@:>@*.\(@<:@0-9@:>@*\).@<:@0-9@:>@*/\1/p')
+            if @<:@ "$macos_version" -gt "7" @:>@; then
+                _JTOPDIR="$(xcrun --show-sdk-path)/System/Library/Frameworks/JavaVM.framework"
+                _JINC="$_JTOPDIR/Headers"
+            else
+                _JTOPDIR="/System/Library/Frameworks/JavaVM.framework"
+                _JINC="$_JTOPDIR/Headers"
+            fi
+            ;;
+        *) _JINC="$_JTOPDIR/include";;
 esac
 _AS_ECHO_LOG([_JTOPDIR=$_JTOPDIR])
 _AS_ECHO_LOG([_JINC=$_JINC])


### PR DESCRIPTION
Find the Java directories within the Xcode bundle on macOS 10.8 and
later.