### PR TITLE
AX_CHECK_ENABLE_DEBUG: Do not conflict with -DNDEBUG

### DIFF
--- a/m4/ax_check_enable_debug.m4
+++ b/m4/ax_check_enable_debug.m4
@@ -42,7 +42,7 @@
 #   permitted in any medium without royalty provided the copyright notice
 #   and this notice are preserved.
 
-#serial 6
+#serial 7
 
 AC_DEFUN([AX_CHECK_ENABLE_DEBUG],[
     AC_BEFORE([$0],[AC_PROG_CC])dnl
@@ -118,7 +118,7 @@ AC_DEFUN([AX_CHECK_ENABLE_DEBUG],[
     dnl Define various variables if debugging is disabled.
     dnl assert.h is a NOP if NDEBUG is defined, so define it by default.
     AS_IF([test "x$enable_debug" = "xyes"],
-      [m4_map_args_w(ax_enable_debug_vars, [AC_DEFINE(], [,,[Define if debugging is enabled])])],
-      [m4_map_args_w(ax_disable_debug_vars, [AC_DEFINE(], [,,[Define if debugging is disabled])])])
+      [m4_map_args_w(ax_enable_debug_vars, [AC_DEFINE(], [,[1],[Define if debugging is enabled])])],
+      [m4_map_args_w(ax_disable_debug_vars, [AC_DEFINE(], [,[1],[Define if debugging is disabled])])])
     ax_enable_debug=$enable_debug
 ])


### PR DESCRIPTION
Since -DNDEBUG is equivalent to "#define NDEBUG 1", explicitly set
the value to ensure that both definitions are equivalent and won't
lead to compiler warnings.

This makes AX_CHECK_ENABLE_DEBUG compatible with AX_CODE_COVERAGE, as
the latter causes -DNDEBUG to be set.

In particular, if AX_COMPILER_FLAGS is also used and thus -Werror
is set (which is the default in that case) this avoids the following
build failure:

./config.h:38:0: error: "NDEBUG" redefined [-Werror]

Submitted in <https://savannah.gnu.org/patch/?9226>

Signed-off-by: Emanuele Aina <emanuele.aina@collabora.com>