### PR TITLE
Add support for Cavium ThunderX2 CN99xx to AX_GCC_ARCHFLAG.

### DIFF
--- a/m4/ax_gcc_archflag.m4
+++ b/m4/ax_gcc_archflag.m4
@@ -65,7 +65,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 19
+#serial 20
 
 AC_DEFUN([AX_GCC_ARCHFLAG],
 [AC_REQUIRE([AC_PROG_CC])
@@ -207,6 +207,13 @@ case $host_cpu in
      cpuarch=`grep 'CPU architecture' /proc/cpuinfo 2> /dev/null | cut -d: -f2 | tr -d " " | head -n 1`
      cpuvar=`grep 'CPU variant' /proc/cpuinfo 2> /dev/null | cut -d: -f2 | tr -d " " | head -n 1`
      case $cpuimpl in
+       0x42) case $cpuarch in
+               8) case $cpuvar in
+                    0x0) ax_gcc_arch="thunderx2t99 vulcan armv8.1-a armv8-a+lse armv8-a native" ;;
+                  esac
+                  ;;
+             esac
+             ;;
        0x43) case $cpuarch in
                8) case $cpuvar in
                     0x0) ax_gcc_arch="thunderx armv8-a native" ;;


### PR DESCRIPTION
This patch adds code to detect Cavium ThunderX2 CN99xx (formely Broadcom
Vulcan) to AX_GCC_ARCHFLAG.