### PR TITLE
AX_IS_RELEASE: use srcdir instead of top_srcdir

### DIFF
--- a/m4/ax_is_release.m4
+++ b/m4/ax_is_release.m4
@@ -44,7 +44,7 @@
 #   permitted in any medium without royalty provided the copyright notice
 #   and this notice are preserved.
 
-#serial 6
+#serial 7
 
 AC_DEFUN([AX_IS_RELEASE],[
     AC_BEFORE([AC_INIT],[$0])
@@ -52,7 +52,7 @@ AC_DEFUN([AX_IS_RELEASE],[
     m4_case([$1],
       [git-directory],[
         # $is_release = (.git directory does not exist)
-        AS_IF([test -d ${top_srcdir}/.git],[ax_is_release=no],[ax_is_release=yes])
+        AS_IF([test -d ${srcdir}/.git],[ax_is_release=no],[ax_is_release=yes])
       ],
       [minor-version],[
         # $is_release = ($minor_version is even)


### PR DESCRIPTION
Autoconf 2.69 does not set the ${top_srcdir} environment variable in configure scripts any more.

${srcdir} and ${ac_top_srcdir} are both available but the Autoconf manual recommends using ${srcdir}:

From https://www.gnu.org/software/autoconf/manual/autoconf.html#Preset-Output-Variables:

> The preset variables which are available during config.status (see Configuration Actions) may also be used during configure tests. For example, it is permissible to reference ‘$srcdir’ when constructing a list of directories to pass via option -I during a compiler feature check. When used in this manner, coupled with the fact that configure is always run from the top build directory, it is sufficient to use just ‘$srcdir’ instead of ‘$top_srcdir’.