### PR TITLE
ax_python_devel: check success of import by return code rather than b…

### DIFF
--- a/m4/ax_python_devel.m4
+++ b/m4/ax_python_devel.m4
@@ -67,7 +67,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 19
+#serial 20
 
 AU_ALIAS([AC_PYTHON_DEVEL], [AX_PYTHON_DEVEL])
 AC_DEFUN([AX_PYTHON_DEVEL],[
@@ -137,7 +137,7 @@ variable to configure. See ``configure --help'' for reference.
 	#
 	AC_MSG_CHECKING([for the distutils Python package])
 	ac_distutils_result=`$PYTHON -c "import distutils" 2>&1`
-	if test -z "$ac_distutils_result"; then
+	if test $? -eq 0; then
 		AC_MSG_RESULT([yes])
 	else
 		AC_MSG_RESULT([no])


### PR DESCRIPTION
…y stderr

In Python 3.7, when you have C locale it will be automatically coerced
to C.UTF-8 and warning will be printed to stderr. This breaks AX_PYTHON_DEVEL.

Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>