### PR TITLE
AX_BOOST_BASE: Fix missing BOOST_LDFLAGS.

### DIFF
--- a/m4/ax_boost_base.m4
+++ b/m4/ax_boost_base.m4
@@ -33,7 +33,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 30
+#serial 31
 
 AC_DEFUN([AX_BOOST_BASE],
 [
@@ -44,9 +44,9 @@ AC_ARG_WITH([boost],
      or disable it (ARG=no)
      @<:@ARG=yes@:>@ ])],
     [
-    if test "$withval" = "no"; then
+    if test "x$withval" = "xno"; then
         want_boost="no"
-    elif test "$withval" = "yes"; then
+    elif test "x$withval" = "xyes"; then
         want_boost="yes"
         ac_boost_path=""
     else
@@ -61,8 +61,7 @@ AC_ARG_WITH([boost-libdir],
         AS_HELP_STRING([--with-boost-libdir=LIB_DIR],
         [Force given directory for boost libraries. Note that this will override library path detection, so use this parameter only if default library detection fails and you know exactly where your boost libraries are located.]),
         [
-        if test -d "$withval"
-        then
+        if test -d "$withval" ; then
                 ac_boost_lib_path="$withval"
         else
                 AC_MSG_ERROR(--with-boost-libdir expected directory name)
@@ -71,15 +70,15 @@ AC_ARG_WITH([boost-libdir],
         [ac_boost_lib_path=""]
 )
 
-if test "x$want_boost" = "xyes"; then
+if test "x$want_boost" = "xyes" ; then
     boost_lib_version_req=ifelse([$1], ,1.20.0,$1)
     boost_lib_version_req_shorten=`expr $boost_lib_version_req : '\([[0-9]]*\.[[0-9]]*\)'`
     boost_lib_version_req_major=`expr $boost_lib_version_req : '\([[0-9]]*\)'`
     boost_lib_version_req_minor=`expr $boost_lib_version_req : '[[0-9]]*\.\([[0-9]]*\)'`
     boost_lib_version_req_sub_minor=`expr $boost_lib_version_req : '[[0-9]]*\.[[0-9]]*\.\([[0-9]]*\)'`
-    if test "x$boost_lib_version_req_sub_minor" = "x" ; then
+    if test -z "$boost_lib_version_req_sub_minor" ; then
         boost_lib_version_req_sub_minor="0"
-        fi
+    fi
     WANT_BOOST_VERSION=`expr $boost_lib_version_req_major \* 100000 \+  $boost_lib_version_req_minor \* 100 \+ $boost_lib_version_req_sub_minor`
     AC_MSG_CHECKING(for boostlib >= $boost_lib_version_req)
     succeeded=no
@@ -115,7 +114,7 @@ if test "x$want_boost" = "xyes"; then
     dnl first we check the system location for boost libraries
     dnl this location ist chosen if boost libraries are installed with the --layout=system option
     dnl or if you install boost with RPM
-    if test "$ac_boost_path" != ""; then
+    if test -n "$ac_boost_path" ; then
         BOOST_CPPFLAGS="-I$ac_boost_path/include"
         for ac_boost_path_tmp in $libsubdirs; do
                 if test -d "$ac_boost_path"/"$ac_boost_path_tmp" ; then
@@ -123,9 +122,9 @@ if test "x$want_boost" = "xyes"; then
                         break
                 fi
         done
-    elif test "$cross_compiling" != yes; then
+    elif test "x$cross_compiling" != "xyes"; then
         for ac_boost_path_tmp in /usr /usr/local /opt /opt/local ; do
-            if test -d "$ac_boost_path_tmp/include/boost" && test -r "$ac_boost_path_tmp/include/boost"; then
+            if test -d "$ac_boost_path_tmp/include/boost" && test -r "$ac_boost_path_tmp/include/boost" ; then
                 for libsubdir in $libsubdirs ; do
                     if ls "$ac_boost_path_tmp/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
                 done
@@ -138,7 +137,7 @@ if test "x$want_boost" = "xyes"; then
 
     dnl overwrite ld flags if we have required special directory with
     dnl --with-boost-libdir parameter
-    if test "$ac_boost_lib_path" != ""; then
+    if test -n "$ac_boost_lib_path" ; then
        BOOST_LDFLAGS="-L$ac_boost_lib_path"
     fi
 
@@ -172,20 +171,20 @@ if test "x$want_boost" = "xyes"; then
 
     dnl if we found no boost with system layout we search for boost libraries
     dnl built and installed without the --layout=system option or for a staged(not installed) version
-    if test "x$succeeded" != "xyes"; then
+    if test "x$succeeded" != "xyes" ; then
         CPPFLAGS="$CPPFLAGS_SAVED"
         LDFLAGS="$LDFLAGS_SAVED"
         BOOST_CPPFLAGS=
-        if test "$ac_boost_lib_path" = ""; then
+        if test -z "$ac_boost_lib_path" ; then
             BOOST_LDFLAGS=
         fi
         _version=0
-        if test "$ac_boost_path" != ""; then
+        if test -n "$ac_boost_path" ; then
             if test -d "$ac_boost_path" && test -r "$ac_boost_path"; then
                 for i in `ls -d $ac_boost_path/include/boost-* 2>/dev/null`; do
                     _version_tmp=`echo $i | sed "s#$ac_boost_path##" | sed 's/\/include\/boost-//' | sed 's/_/./'`
                     V_CHECK=`expr $_version_tmp \> $_version`
-                    if test "$V_CHECK" = "1" ; then
+                    if test "x$V_CHECK" = "x1" ; then
                         _version=$_version_tmp
                     fi
                     VERSION_UNDERSCORE=`echo $_version | sed 's/\./_/'`
@@ -207,13 +206,13 @@ if test "x$want_boost" = "xyes"; then
                 fi
             fi
         else
-            if test "$cross_compiling" != yes; then
+            if test "x$cross_compiling" != "xyes" ; then
                 for ac_boost_path in /usr /usr/local /opt /opt/local ; do
-                    if test -d "$ac_boost_path" && test -r "$ac_boost_path"; then
+                    if test -d "$ac_boost_path" && test -r "$ac_boost_path" ; then
                         for i in `ls -d $ac_boost_path/include/boost-* 2>/dev/null`; do
                             _version_tmp=`echo $i | sed "s#$ac_boost_path##" | sed 's/\/include\/boost-//' | sed 's/_/./'`
                             V_CHECK=`expr $_version_tmp \> $_version`
-                            if test "$V_CHECK" = "1" ; then
+                            if test "x$V_CHECK" = "x1" ; then
                                 _version=$_version_tmp
                                 best_path=$ac_boost_path
                             fi
@@ -223,7 +222,7 @@ if test "x$want_boost" = "xyes"; then
 
                 VERSION_UNDERSCORE=`echo $_version | sed 's/\./_/'`
                 BOOST_CPPFLAGS="-I$best_path/include/boost-$VERSION_UNDERSCORE"
-                if test "$ac_boost_lib_path" = ""; then
+                if test -z "$ac_boost_lib_path" ; then
                     for libsubdir in $libsubdirs ; do
                         if ls "$best_path/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
                     done
@@ -231,7 +230,7 @@ if test "x$want_boost" = "xyes"; then
                 fi
             fi
 
-            if test "x$BOOST_ROOT" != "x"; then
+            if test -n "$BOOST_ROOT" ; then
                 for libsubdir in $libsubdirs ; do
                     if ls "$BOOST_ROOT/stage/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
                 done
@@ -240,7 +239,7 @@ if test "x$want_boost" = "xyes"; then
                     stage_version=`echo $version_dir | sed 's/boost_//' | sed 's/_/./g'`
                         stage_version_shorten=`expr $stage_version : '\([[0-9]]*\.[[0-9]]*\)'`
                     V_CHECK=`expr $stage_version_shorten \>\= $_version`
-                    if test "$V_CHECK" = "1" -a "$ac_boost_lib_path" = "" ; then
+                    if test "x$V_CHECK" = "x1" && test -z "$ac_boost_lib_path" ; then
                         AC_MSG_NOTICE(We will use a staged boost library from $BOOST_ROOT)
                         BOOST_CPPFLAGS="-I$BOOST_ROOT"
                         BOOST_LDFLAGS="-L$BOOST_ROOT/stage/$libsubdir"
@@ -272,8 +271,8 @@ if test "x$want_boost" = "xyes"; then
         AC_LANG_POP([C++])
     fi
 
-    if test "$succeeded" != "yes" ; then
-        if test "$_version" = "0" ; then
+    if test "x$succeeded" != "xyes" ; then
+        if test "x$_version" = "x0" ; then
             AC_MSG_NOTICE([[We could not detect the boost libraries (version $boost_lib_version_req_shorten or higher). If you have a staged boost library (still not installed) please specify \$BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See http://randspringer.de/boost for more documentation.]])
         else
             AC_MSG_NOTICE([Your boost libraries seems to old (version $_version).])

--- a/m4/ax_boost_base.m4
+++ b/m4/ax_boost_base.m4
@@ -33,7 +33,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 29
+#serial 30
 
 AC_DEFUN([AX_BOOST_BASE],
 [
@@ -196,6 +196,14 @@ if test "x$want_boost" = "xyes"; then
                     if test -d "$ac_boost_path/boost" && test -r "$ac_boost_path/boost"; then
                         BOOST_CPPFLAGS="-I$ac_boost_path"
                     fi
+                fi
+                dnl if we found something and BOOST_LDFLAGS was unset before
+                dnl (because "$ac_boost_lib_path" = ""), set it here.
+                if test -n "$BOOST_CPPFLAGS" && test -z "$BOOST_LDFLAGS"; then
+                    for libsubdir in $libsubdirs ; do
+                        if ls "$ac_boost_path/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
+                    done
+                    BOOST_LDFLAGS="-L$ac_boost_path/$libsubdir"
                 fi
             fi
         else


### PR DESCRIPTION
AX_BOOST_BASE first checks if Boost is installed in a standard location
and sets BOOST_CPPFLAGS and BOOST_LDFLAGS accordingly.

If Boost cannot be found, these variables are reset. Further proceedings
depend on whether the actual location was passed in via
`--with-boost=<path>` or not. If it was, BOOST_CPPFLAGS is determined
automatically based on the given path. This automatic detection, however, did
not include BOOST_LDFLAGS.

Consequently, if Boost is in a non-standard location that is given via
`--with-boost`, the user would also have to specify `--with-boost-libdir`.

This commit fixes this issue by also determining BOOST_LDFLAGS
automatically in this particular branch of execution. The performed
check is very similar to the one done in various other locations of the
macro.

Additionally, a few portability issues around the use of `test` are fixed.