### PR TITLE
Fix AX_LIB_ORACLE_OCI macro for plain C

### DIFF
--- a/m4/ax_lib_oracle_oci.m4
+++ b/m4/ax_lib_oracle_oci.m4
@@ -48,7 +48,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 15
+#serial 16
 
 AC_DEFUN([AX_LIB_ORACLE_OCI],
 [
@@ -156,25 +156,28 @@ Please, locate Oracle directories using --with-oci or \
         dnl Depending on later Oracle version detection,
         dnl -lnnz10 flag might be removed for older Oracle < 10.x
         saved_LDFLAGS="$LDFLAGS"
-        oci_ldflags="-L$oracle_lib_dir -lclntsh"
+        saved_LIBS="$LIBS"
+        oci_ldflags="-L$oracle_lib_dir"
+        oci_libs="-lclntsh"
         LDFLAGS="$LDFLAGS $oci_ldflags"
+        LIBS="$LIBS $oci_libs"
 
         dnl
         dnl Check OCI headers
         dnl
         AC_MSG_CHECKING([for Oracle OCI headers in $oracle_include_dir])
 
-        AC_LANG_PUSH(C++)
+        AC_LANG_PUSH(C)
         AC_COMPILE_IFELSE([
             AC_LANG_PROGRAM([[@%:@include <oci.h>]],
                 [[
 #if defined(OCI_MAJOR_VERSION)
 #if OCI_MAJOR_VERSION == 10 && OCI_MINOR_VERSION == 2
-// Oracle 10.2 detected
+/* Oracle 10.2 detected */
 #endif
 #elif defined(OCI_V7_SYNTAX)
-// OK, older Oracle detected
-// TODO - mloskot: find better macro to check for older versions;
+/* OK, older Oracle detected */
+/* TODO - mloskot: find better macro to check for older versions; */
 #else
 #  error Oracle oci.h header not found
 #endif
@@ -195,7 +198,7 @@ Please, locate Oracle directories using --with-oci or \
             AC_MSG_RESULT([not found])
             ]
         )
-        AC_LANG_POP([C++])
+        AC_LANG_POP([C])
 
         dnl
         dnl Check OCI libraries
@@ -204,7 +207,7 @@ Please, locate Oracle directories using --with-oci or \
 
             AC_MSG_CHECKING([for Oracle OCI libraries in $oracle_lib_dir])
 
-            AC_LANG_PUSH(C++)
+            AC_LANG_PUSH(C)
             AC_LINK_IFELSE([
                 AC_LANG_PROGRAM([[@%:@include <oci.h>]],
                     [[
@@ -214,7 +217,7 @@ if (envh) OCIHandleFree(envh, OCI_HTYPE_ENV);
                     ]]
                 )],
                 [
-                ORACLE_OCI_LDFLAGS="$oci_ldflags"
+                ORACLE_OCI_LDFLAGS="$oci_ldflags $oci_libs"
                 oci_lib_found="yes"
                 AC_MSG_RESULT([yes])
                 ],
@@ -223,11 +226,12 @@ if (envh) OCIHandleFree(envh, OCI_HTYPE_ENV);
                 AC_MSG_RESULT([not found])
                 ]
             )
-            AC_LANG_POP([C++])
+            AC_LANG_POP([C])
         fi
 
         CPPFLAGS="$saved_CPPFLAGS"
         LDFLAGS="$saved_LDFLAGS"
+        LIBS="$saved_LIBS"
     fi
 
     dnl


### PR DESCRIPTION
1. Use C compiler, not C++.
2. Split LDFLAGS into LDFLAGS and LIBS.
   However, merge them back to ORACLE_OCI_LDFLAGS afterwards
   to preserve interface backward compatibility.
3. Replace C++ style comments with C style.

Resolves mloskot/autotools-modules#2
