### PR TITLE
Fix check for system libraries in both lib64 and lib

### DIFF
--- a/m4/ax_boost_base.m4
+++ b/m4/ax_boost_base.m4
@@ -33,7 +33,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 42
+#serial 43
 
 # example boost program (need to pass version)
 m4_define([_AX_BOOST_BASE_PROGRAM],
@@ -114,7 +114,7 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
     AS_CASE([${host_cpu}],
       [x86_64],[libsubdirs="lib64 libx32 lib lib64"],
       [ppc64|s390x|sparc64|aarch64|ppc64le],[libsubdirs="lib64 lib lib64"],
-      [libsubdirs="lib"],
+      [libsubdirs="lib"]
     )
 
     dnl allow for real multi-arch paths e.g. /usr/lib/x86_64-linux-gnu. Give


### PR DESCRIPTION
if host_cpu != [x86_64|ppc64|s390x|sparc64|aarch64|ppc64le] libsubdirs = "",
but it is necessary libsubdirs = "lib"
Invalid execution, superfluous comma.
[qbittorrent issue #7845](https://github.com/qbittorrent/qBittorrent/issues/7845)