### PR TITLE
Fix checks for boost chrono and unit_test

### DIFF
--- a/m4/ax_boost_chrono.m4
+++ b/m4/ax_boost_chrono.m4
@@ -68,7 +68,7 @@ AC_DEFUN([AX_BOOST_CHRONO],
 			 CXXFLAGS_SAVE=$CXXFLAGS
 
 			 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/chrono.hpp>]],
-                                   [[boost::chrono::system_clock::time_point time;]])],
+                                   [[boost::chrono::system_clock::time_point* time = new boost::chrono::system_clock::time_point; delete time;]])],
                    ax_cv_boost_chrono=yes, ax_cv_boost_chrono=no)
 			 CXXFLAGS=$CXXFLAGS_SAVE
              AC_LANG_POP([C++])

--- a/m4/ax_boost_unit_test_framework.m4
+++ b/m4/ax_boost_unit_test_framework.m4
@@ -66,7 +66,7 @@ AC_DEFUN([AX_BOOST_UNIT_TEST_FRAMEWORK],
         [AC_LANG_PUSH([C++])
 			 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/test/unit_test.hpp>]],
                                     [[using boost::unit_test::test_suite;
-							 test_suite* test= BOOST_TEST_SUITE( "Unit test example 1" ); return 0;]])],
+							 test_suite* test= BOOST_TEST_SUITE( "Unit test example 1" ); if (test == NULL) { return 1; } else { return 0; }]])],
                    ax_cv_boost_unit_test_framework=yes, ax_cv_boost_unit_test_framework=no)
          AC_LANG_POP([C++])
 		])


### PR DESCRIPTION
The two test programs could produce a compiler warnings (or errors if
-Werror is engaged) about unused variables and fail the checks. It is
better to have test programs that do not produce warnings.