### PR TITLE
AX_LIB_HDF5: fix order of flags

### DIFF
--- a/m4/ax_lib_hdf5.m4
+++ b/m4/ax_lib_hdf5.m4
@@ -88,7 +88,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 18
+#serial 19
 
 AC_DEFUN([AX_LIB_HDF5], [
 
@@ -226,18 +226,18 @@ HDF5 support is being disabled (equivalent to --with-hdf5=no).
         for arg in $HDF5_SHOW $HDF5_tmp_flags ; do
           case "$arg" in
             -I*) echo $HDF5_CPPFLAGS | $GREP -e "$arg" 2>&1 >/dev/null \
-                  || HDF5_CPPFLAGS="$arg $HDF5_CPPFLAGS"
+                  || HDF5_CPPFLAGS="$HDF5_CPPFLAGS $arg"
               ;;
             -L*) echo $HDF5_LDFLAGS | $GREP -e "$arg" 2>&1 >/dev/null \
-                  || HDF5_LDFLAGS="$arg $HDF5_LDFLAGS"
+                  || HDF5_LDFLAGS="$HDF5_LDFLAGS $arg"
               ;;
             -l*) echo $HDF5_LIBS | $GREP -e "$arg" 2>&1 >/dev/null \
-                  || HDF5_LIBS="$arg $HDF5_LIBS"
+                  || HDF5_LIBS="$HDF5_LIBS $arg"
               ;;
           esac
         done
 
-        HDF5_LIBS="$HDF5_LIBS -lhdf5"
+        HDF5_LIBS="-lhdf5 $HDF5_LIBS"
         AC_MSG_RESULT([yes (version $[HDF5_VERSION])])
 
         dnl See if we can compile
@@ -257,7 +257,7 @@ HDF5 support is being disabled (equivalent to --with-hdf5=no).
           AC_MSG_WARN([Unable to compile HDF5 test program])
         fi
         dnl Look for HDF5's high level library
-        AC_HAVE_LIBRARY([hdf5_hl], [HDF5_LIBS="$HDF5_LIBS -lhdf5_hl"], [], [])
+        AC_HAVE_LIBRARY([hdf5_hl], [HDF5_LIBS="-lhdf5_hl $HDF5_LIBS"], [], [])
 
         CC=$ax_lib_hdf5_save_CC
         CPPFLAGS=$ax_lib_hdf5_save_CPPFLAGS
@@ -278,14 +278,14 @@ HDF5 support is being disabled (equivalent to --with-hdf5=no).
             do
               case "$arg" in #(
                 -I*) echo $HDF5_FFLAGS | $GREP -e "$arg" >/dev/null \
-                      || HDF5_FFLAGS="$arg $HDF5_FFLAGS"
+                      || HDF5_FFLAGS="$HDF5_FFLAGS $arg"
                   ;;#(
                 -L*) echo $HDF5_FFLAGS | $GREP -e "$arg" >/dev/null \
-                      || HDF5_FFLAGS="$arg $HDF5_FFLAGS"
+                      || HDF5_FFLAGS="$HDF5_FFLAGS $arg"
                      dnl HDF5 installs .mod files in with libraries,
                      dnl but some compilers need to find them with -I
                      echo $HDF5_FFLAGS | $GREP -e "-I${arg#-L}" >/dev/null \
-                      || HDF5_FFLAGS="-I${arg#-L} $HDF5_FFLAGS"
+                      || HDF5_FFLAGS="$HDF5_FFLAGS -I${arg#-L}"
                   ;;
               esac
             done


### PR DESCRIPTION
When iterating over flags from `h5cc`, the `HDF5_{CPPFLAGS,LDFLAGS,LIBS}` variables were assembled in reverse order. This causes problems when linking against static libraries. This patch assembles those variables in the original order.

In master, `HDF5_LIBS` comes out to be: `-lm -ldl -lz -lpthread  -lhdf5 -lhdf5_hl`

With this patch, it comes out to be: `-lhdf5_hl -lhdf5  -lpthread -lz -ldl -lm`

This matches the original order from `h5cc -show`:

```bash
$ h5cc -shlib -show
gcc -fmessage-length=0 -grecord-gcc-switches -O2 -Wall \
-D_FORTIFY_SOURCE=2 -fstack-protector-strong \
-funwind-tables -fasynchronous-unwind-tables \
-fstack-clash-protection -g \
-L/usr/lib64 -lhdf5_hl -lhdf5 -lpthread -lz -ldl -lm -Wl,-rpath -Wl,/usr/lib64
```

I've checked this creates the variables with all of the flags in the original order on openSUSE Tumbleweed with the system version of HDF5 (1.10.1), and also on Ubuntu 16.04 with a custom built version of HDF5 (1.8.18) configured with several optional dependencies in custom locations.