### PR TITLE
ax_cxx_compile_stdcxx.m4: Drop the check for default C++ version support

### DIFF
--- a/m4/ax_cxx_compile_stdcxx.m4
+++ b/m4/ax_cxx_compile_stdcxx.m4
@@ -33,14 +33,14 @@
 #   Copyright (c) 2014, 2015 Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
 #   Copyright (c) 2015 Paul Norman <penorman@mac.com>
 #   Copyright (c) 2015 Moritz Klammler <moritz@klammler.eu>
-#   Copyright (c) 2016 Krzesimir Nowak <qdlacz@gmail.com>
+#   Copyright (c) 2016, 2018 Krzesimir Nowak <qdlacz@gmail.com>
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 8
+#serial 9
 
 dnl  This macro is based on the code from the AX_CXX_COMPILE_STDCXX_11 macro
 dnl  (serial version number 13).
@@ -60,14 +60,6 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
         [m4_fatal([invalid third argument `$3' to AX_CXX_COMPILE_STDCXX])])
   AC_LANG_PUSH([C++])dnl
   ac_success=no
-  AC_CACHE_CHECK(whether $CXX supports C++$1 features by default,
-  ax_cv_cxx_compile_cxx$1,
-  [AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
-    [ax_cv_cxx_compile_cxx$1=yes],
-    [ax_cv_cxx_compile_cxx$1=no])])
-  if test x$ax_cv_cxx_compile_cxx$1 = xyes; then
-    ac_success=yes
-  fi
 
   m4_if([$2], [noext], [], [dnl
   if test x$ac_success = xno; then


### PR DESCRIPTION
This is the same thing as in https://savannah.gnu.org/patch/index.php?9572, but I guess patches on github are processed faster. Please let me know which way is preferred.

The problem with the check is that it can't detect whether the version
is with extensions or not. So it can't take the "noext" or "ext"
option into account.

This may be a problem when an extended version of C++ has a feature
that conflicts with another feature from the C++ standard and we have
no way to tell the macro to add a "-std" flag anyway.

An example:

    using namespace std::complex_literals;
    std::complex<double> c = 1.0;
    c += 1.0i;
    std::cout << "abs" << c << " = " << abs(c) << '\n';

Here, the "1.0i" constant is either a GCC extension if compiled with
-std=gnu++14 or a standard C++ operator if compiled with
-std=c++14. If a GCC extension is used, the snippet fails to
compile. Unfortunately, recent GCC versions default to gnu++14, so
this code fails to compile by default.

Dropping the check forces the macro to evaluate compiler flags with
taking the "ext"/"noext" option into account.

Issue spotted by Frédéric Mangano-Tarumi.