### PR TITLE
cfg.mk: use 'touch -d' instead of 'touch --date'

### DIFF
--- a/cfg.mk
+++ b/cfg.mk
@@ -33,7 +33,7 @@ $(STAGEDIR)/manifest:
 
 $(STAGEDIR)/%.m4 : $(M4DIR)/%.m4 $(STAGEDIR)/manifest $(srcdir)/macro.py $(srcdir)/macro2m4.py
 	$(PYTHON) $(srcdir)/macro2m4.py "$<" "$@"
-	@diff -u "$<" "$@" || (touch --date="1970-01-01 01:00:00" "$@"; false)
+	@diff -u "$<" "$@" || (touch -d "1970-01-01 01:00:00" "$@"; false)
 
 $(DOCDIR)/%.texi : $(STAGEDIR)/%.m4 $(srcdir)/macro2texi.py $(srcdir)/macro.py
 	$(PYTHON) $(srcdir)/macro2texi.py "$<" "$@"


### PR DESCRIPTION
Long options are not supported by POSIX and many non-GNU systems. This commit fixes error when using autoconf-archive on FreeBSD.